### PR TITLE
[WUMO-28] Member 닉네임 중복체크 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
@@ -50,7 +50,7 @@ public class MemberController {
 		@RequestBody @Valid MemberEmailCheckRequest memberEmailCheckRequest) {
 
 		memberService.checkEmail(memberEmailCheckRequest);
-		return ResponseEntity.ok().build();
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 	@PostMapping("/check-nickname")
@@ -58,7 +58,8 @@ public class MemberController {
 	public ResponseEntity<Void> checkNickname(
 		@RequestBody @Valid MemberNicknameCheckRequest memberNicknameCheckRequest) {
 
-		return ResponseEntity.ok().build();
+		memberService.checkNickname(memberNicknameCheckRequest);
+		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
 	}
 
 	@PostMapping("/login")

--- a/src/main/java/org/prgrms/wumo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/repository/MemberRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByEmail(Email email);
+
+	boolean existsByNickname(String nickname);
 }

--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.member.service;
 
 import org.prgrms.wumo.domain.member.dto.request.MemberEmailCheckRequest;
+import org.prgrms.wumo.domain.member.dto.request.MemberNicknameCheckRequest;
 import org.prgrms.wumo.domain.member.model.Email;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
@@ -20,7 +21,17 @@ public class MemberService {
 		}
 	}
 
+	public void checkNickname(MemberNicknameCheckRequest memberNicknameCheckRequest) {
+		if (checkNicknameDuplicate(memberNicknameCheckRequest.nickname())) {
+			throw new DuplicateException("닉네임이 중복됩니다.");
+		}
+	}
+
 	private boolean checkEmailDuplicate(Email email) {
 		return memberRepository.existsByEmail(email);
+	}
+
+	private boolean checkNicknameDuplicate(String nickname) {
+		return memberRepository.existsByNickname(nickname);
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgrms.wumo.MysqlTestContainer;
 import org.prgrms.wumo.domain.member.dto.request.MemberEmailCheckRequest;
+import org.prgrms.wumo.domain.member.dto.request.MemberNicknameCheckRequest;
 import org.prgrms.wumo.domain.member.model.Email;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -45,6 +46,24 @@ public class MemberControllerTest extends MysqlTestContainer {
 
 		//then
 		resultActions
-			.andExpect(status().isOk());
+			.andExpect(status().isNoContent());
+	}
+
+	@Test
+	@DisplayName("회원 닉네임의 중복체크를 한다")
+	void check_nickname_not_duplicate() throws Exception {
+		//given
+		MemberNicknameCheckRequest memberNicknameCheckRequest
+			= new MemberNicknameCheckRequest("오예스");
+
+		//when
+		ResultActions resultActions
+			= mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/members/check-nickname")
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.content(objectMapper.writeValueAsString(memberNicknameCheckRequest)));
+
+		//then
+		resultActions
+			.andExpect(status().isNoContent());
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -11,6 +11,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.prgrms.wumo.domain.member.dto.request.MemberEmailCheckRequest;
+import org.prgrms.wumo.domain.member.dto.request.MemberNicknameCheckRequest;
 import org.prgrms.wumo.domain.member.model.Email;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
@@ -26,8 +27,8 @@ public class MemberServiceTest {
 	MemberRepository memberRepository;
 
 	@Nested
-	@DisplayName("registerMember 메소드는 이메일 중복체크 요청 시 ")
-	class RegisterMember {
+	@DisplayName("checkEmail 메소드는 이메일 중복체크 요청 시 ")
+	class CheckEmail {
 
 		//given
 		Email email = new Email("5yes@gmail.com");
@@ -46,6 +47,30 @@ public class MemberServiceTest {
 			assertThatThrownBy(() -> memberService.checkEmail(memberEmailCheckRequest))
 				.isInstanceOf(DuplicateException.class)
 				.hasMessage("이메일이 중복됩니다.");
+		}
+	}
+
+	@Nested
+	@DisplayName("checkNickname 메소드는 닉네임 중복체크 요청 시 ")
+	class CheckNickname {
+
+		//given
+		String nickname = "오예스";
+
+		MemberNicknameCheckRequest memberNicknameCheckRequest
+			= new MemberNicknameCheckRequest(nickname);
+
+		@Test
+		@DisplayName("이미 사용중인 닉네임이라면 예외가 발생한다")
+		void with_exist_emil() {
+			//mocking
+			given(memberRepository.existsByNickname(nickname))
+				.willReturn(true);
+
+			//when, then
+			assertThatThrownBy(() -> memberService.checkNickname(memberNicknameCheckRequest))
+				.isInstanceOf(DuplicateException.class)
+				.hasMessage("닉네임이 중복됩니다.");
 		}
 	}
 }


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->
- 회원 닉네임 중복체크 기능 구현 및 테스트 코드

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-136], [WUMO-137]

[WUMO-136]: https://shoekream.atlassian.net/browse/WUMO-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-137]: https://shoekream.atlassian.net/browse/WUMO-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ