### PR TITLE
[WUMO-34] Party 등록 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
@@ -8,6 +8,7 @@ import org.prgrms.wumo.domain.party.dto.request.PartyUpdateRequest;
 import org.prgrms.wumo.domain.party.dto.response.PartyGetAllResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyGetDetailResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
+import org.prgrms.wumo.domain.party.service.PartyService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,25 +23,29 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/v1/party")
 @Tag(name = "모임 API")
 public class PartyController {
+
+	private final PartyService partyService;
 
 	@PostMapping
 	@Operation(summary = "모임 등록")
 	public ResponseEntity<PartyRegisterResponse> registerParty(
 			@RequestBody @Valid PartyRegisterRequest partyRegisterRequest
 	) {
-		return new ResponseEntity<>(null, HttpStatus.CREATED);
+		return new ResponseEntity<>(partyService.registerParty(partyRegisterRequest), HttpStatus.CREATED);
 	}
 
 	@GetMapping("/members/{memberId}")
 	@Operation(summary = "사용자 기준 모임 목록 조회")
 	public ResponseEntity<PartyGetAllResponse> getAllParty(
 			@PathVariable @Parameter(description = "사용자 식별자", required = true) Long memberId,
-			@Valid PartyGetRequest request
+			@Valid PartyGetRequest partyGetRequest
 	) {
 		return ResponseEntity.ok(null);
 	}
@@ -57,7 +62,7 @@ public class PartyController {
 	@Operation(summary = "모임 수정")
 	public ResponseEntity<Void> updateParty(
 			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId,
-			@RequestBody @Valid PartyUpdateRequest request
+			@RequestBody @Valid PartyUpdateRequest partyUpdateRequest
 	) {
 		return ResponseEntity.ok(null);
 	}

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
@@ -1,6 +1,6 @@
 package org.prgrms.wumo.domain.party.dto.request;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -19,14 +19,14 @@ public record PartyRegisterRequest(
 
 		@NotNull(message = "시작일은 필수 입력사항입니다.")
 		@Schema(description = "시작일", example = "2023-02-21", required = true)
-		LocalDate startDate,
+		LocalDateTime startDate,
 
 		@NotNull(message = "종료일은 필수 입력사항입니다.")
 		@Schema(description = "종료일", example = "2023-02-22", required = true)
-		LocalDate endDate,
+		LocalDateTime endDate,
 
 		@Length(max = 255, message = "모임 설명은 {max}자를 초과할 수 없습니다.")
-		@Schema(description = "종료일", example = "팀 설립 기념 워크샵", required = true)
+		@Schema(description = "모임 설명", example = "팀 설립 기념 워크샵", required = true)
 		String description,
 
 		@Length(max = 255, message = "이미지 경로는 {max}자를 초과할 수 없습니다.")

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
@@ -1,0 +1,7 @@
+package org.prgrms.wumo.domain.party.repository;
+
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
+}

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyRepository.java
@@ -1,0 +1,7 @@
+package org.prgrms.wumo.domain.party.repository;
+
+import org.prgrms.wumo.domain.party.model.Party;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyRepository extends JpaRepository<Party, Long> {
+}

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -1,0 +1,51 @@
+package org.prgrms.wumo.domain.party.service;
+
+import static org.prgrms.wumo.global.mapper.PartyMapper.toParty;
+import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyRegisterResponse;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PartyService {
+
+	private final MemberRepository memberRepository;
+
+	private final PartyRepository partyRepository;
+
+	private final PartyMemberRepository partyMemberRepository;
+
+	@Transactional
+	public PartyRegisterResponse registerParty(PartyRegisterRequest partyRegisterRequest) {
+		// 모임 엔티티 저장
+		Party party = toParty(partyRegisterRequest);
+		party = partyRepository.save(party);
+
+		// 모임장 저장
+		Member member = memberRepository.findById(partyRegisterRequest.memberId())
+				.orElseThrow(() -> new EntityNotFoundException("사용자 아이디에 문제가 발생했습니다."));
+		PartyMember partyLeader = PartyMember.builder()
+				.member(member)
+				.party(party)
+				.role(partyRegisterRequest.role())
+				.isLeader(true)
+				.build();
+		partyMemberRepository.save(partyLeader);
+
+		return toPartyRegisterResponse(party);
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package org.prgrms.wumo.global.exception;
 
+import javax.persistence.EntityNotFoundException;
+
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
 import org.prgrms.wumo.global.exception.custom.ImageDeleteFailedException;
 import org.prgrms.wumo.global.exception.custom.ImageUploadFailedException;
@@ -14,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler({
-			DuplicateException.class,
+			DuplicateException.class, EntityNotFoundException.class,
 			ImageUploadFailedException.class, IllegalArgumentException.class, ImageDeleteFailedException.class
 	})
 	public ResponseEntity<ExceptionResponse> handleException(RuntimeException runtimeException) {

--- a/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
@@ -1,0 +1,28 @@
+package org.prgrms.wumo.global.mapper;
+
+import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
+import org.prgrms.wumo.domain.party.model.Party;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PartyMapper {
+
+	public static Party toParty(PartyRegisterRequest partyRegisterRequest) {
+		return Party.builder()
+				.name(partyRegisterRequest.name())
+				.startDate(partyRegisterRequest.startDate())
+				.endDate(partyRegisterRequest.endDate())
+				.description(partyRegisterRequest.description())
+				.coverImage(partyRegisterRequest.coverImage())
+				.password(partyRegisterRequest.password())
+				.build();
+	}
+
+	public static PartyRegisterResponse toPartyRegisterResponse(Party party) {
+		return new PartyRegisterResponse(party.getId());
+	}
+
+}

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -46,9 +46,9 @@ class PartyControllerTest extends MysqlTestContainer {
 	void setup() {
 		member = memberRepository.save(
 				Member.builder()
-						.email("5yes@gmail.com")
+						.email("ted-change@gmail.com")
 						.password("qwe12345")
-						.nickname("오예스오리지널")
+						.nickname("테드창")
 						.build()
 		);
 	}

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -1,0 +1,89 @@
+package org.prgrms.wumo.domain.party.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgrms.wumo.MysqlTestContainer;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("PartyController 를 통해 ")
+class PartyControllerTest extends MysqlTestContainer {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	private Member member;
+
+	@BeforeEach
+	void setup() {
+		member = memberRepository.save(
+				Member.builder()
+						.email("5yes@gmail.com")
+						.password("qwe12345")
+						.nickname("오예스오리지널")
+						.build()
+		);
+	}
+
+	@AfterEach
+	void clean() {
+		memberRepository.deleteAll();
+		member = null;
+	}
+
+	@Test
+	@DisplayName("모임을 생성할 수 있다.")
+	void registerParty() throws Exception {
+		//given
+		PartyRegisterRequest partyRegisterRequest = new PartyRegisterRequest(
+				"오예스 워크샵",
+				LocalDateTime.now(),
+				LocalDateTime.now().plusDays(1),
+				"팀 설립 기념 워크샵",
+				"https://~.jpeg",
+				"1234",
+				member.getId(),
+				"총무"
+		);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/party")
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.content(objectMapper.writeValueAsString(partyRegisterRequest)));
+
+		//then
+		resultActions
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.id").isNotEmpty())
+				.andDo(print());
+	}
+
+}

--- a/src/test/java/org/prgrms/wumo/domain/party/model/PartyTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/model/PartyTest.java
@@ -1,0 +1,22 @@
+package org.prgrms.wumo.domain.party.model;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Party 엔티티를 생성할 때")
+class PartyTest {
+
+	@Test
+	@DisplayName("모임 시작일보다 모임 종료일이 빠르면 예외가 발생한다.")
+	void checkEndDateIsBeforeStartDate() {
+		assertThrows(IllegalArgumentException.class, () -> Party.builder()
+						.startDate(LocalDateTime.now())
+						.endDate(LocalDateTime.now().minusDays(1))
+						.build());
+	}
+
+}

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -1,0 +1,130 @@
+package org.prgrms.wumo.domain.party.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+
+@DisplayName("PartyService 의")
+@ExtendWith(MockitoExtension.class)
+class PartyServiceTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	PartyRepository partyRepository;
+
+	@Mock
+	PartyMemberRepository partyMemberRepository;
+
+	@InjectMocks
+	PartyService partyService;
+
+	@Nested
+	@DisplayName("registerParty 메소드는 등록 요청시")
+	class RegisterParty {
+		//given
+		Member member = Member.builder()
+				.id(1L)
+				.email("5yes@gmail.com")
+				.nickname("오예스오리지널")
+				.password("qwe12345")
+				.build();
+		PartyRegisterRequest partyRegisterRequest = new PartyRegisterRequest(
+				"오예스 워크샵",
+				LocalDateTime.now(),
+				LocalDateTime.now().plusDays(1),
+				"팀 설립 기념 워크샵",
+				"https://~.jpeg",
+				"1234",
+				1L,
+				"총무"
+		);
+		Party party = Party.builder()
+				.id(1L)
+				.name(partyRegisterRequest.name())
+				.startDate(partyRegisterRequest.startDate())
+				.endDate(partyRegisterRequest.endDate())
+				.description(partyRegisterRequest.description())
+				.coverImage(partyRegisterRequest.coverImage())
+				.password(partyRegisterRequest.password())
+				.build();
+		PartyMember partyMember = PartyMember.builder()
+				.member(member)
+				.party(party)
+				.role(partyRegisterRequest.role())
+				.isLeader(true)
+				.build();
+
+		@Test
+		@DisplayName("모임을 생성하고 생성을 요청한 사용자를 파티장으로 등록한다.")
+		void success() {
+			//mocking
+			given(partyRepository.save(any(Party.class)))
+					.willReturn(party);
+			given(memberRepository.findById(member.getId()))
+					.willReturn(Optional.of(member));
+			given(partyMemberRepository.save(any(PartyMember.class)))
+					.willReturn(partyMember);
+
+			//when
+			PartyRegisterResponse response = partyService.registerParty(partyRegisterRequest);
+
+			//then
+			then(partyRepository)
+					.should()
+					.save(any(Party.class));
+			then(memberRepository)
+					.should()
+					.findById(any(Long.class));
+			then(partyMemberRepository)
+					.should()
+					.save(any(PartyMember.class));
+
+			assertThat(response.id()).isEqualTo(party.getId());
+		}
+		@Test
+		@DisplayName("유효하지 않은 사용자면 예외가 발생한다.")
+		void failed() {
+			//mocking
+			given(partyRepository.save(any(Party.class)))
+					.willReturn(party);
+			given(memberRepository.findById(member.getId()))
+					.willReturn(Optional.empty());
+
+			//when
+			//then
+			Assertions.assertThrows(EntityNotFoundException.class, () -> partyService.registerParty(partyRegisterRequest));
+
+			then(partyMemberRepository)
+					.should(never())
+					.save(any(PartyMember.class));
+		}
+
+	}
+
+}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약현

<!-- 작업을 간략하게 요약해주세요 -->

- 모임 등록 기능 구현

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 등록 로직에 "파티 등록", "파티장 조회 및 등록"이 포함되어 있습니다.
- MemberRepository는 어느 서비스에서라도 쓰는 게 좋지 않을까요?

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-145], [WUMO-147]

[WUMO-145]: https://shoekream.atlassian.net/browse/WUMO-145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-147]: https://shoekream.atlassian.net/browse/WUMO-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ