### PR TITLE
[WUMO-38] Party 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
@@ -47,7 +47,7 @@ public class PartyController {
 			@PathVariable @Parameter(description = "사용자 식별자", required = true) Long memberId,
 			@Valid PartyGetRequest partyGetRequest
 	) {
-		return ResponseEntity.ok(null);
+		return ResponseEntity.ok(partyService.getAllParty(memberId, partyGetRequest));
 	}
 
 	@GetMapping("/{partyId}")

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetDetailResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetDetailResponse.java
@@ -1,6 +1,6 @@
 package org.prgrms.wumo.domain.party.dto.response;
 
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -14,10 +14,10 @@ public record PartyGetDetailResponse(
 		String name,
 
 		@Schema(description = "시작일", example = "2023-02-21", required = true)
-		LocalDate startDate,
+		LocalDateTime startDate,
 
 		@Schema(description = "종료일", example = "2023-02-22", required = true)
-		LocalDate endDate,
+		LocalDateTime endDate,
 
 		@Schema(description = "종료일", example = "팀 설립 기념 워크샵", required = true)
 		String description,

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
@@ -1,7 +1,13 @@
 package org.prgrms.wumo.domain.party.repository;
 
+import java.util.List;
+
+import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
+
+	List<PartyMember> findAllByMember(Member member);
+
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -1,13 +1,18 @@
 package org.prgrms.wumo.domain.party.service;
 
 import static org.prgrms.wumo.global.mapper.PartyMapper.toParty;
+import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetAllResponse;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyRegisterResponse;
+
+import java.util.List;
 
 import javax.persistence.EntityNotFoundException;
 
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.dto.request.PartyGetRequest;
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.dto.response.PartyGetAllResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
@@ -35,8 +40,7 @@ public class PartyService {
 		party = partyRepository.save(party);
 
 		// 모임장 저장
-		Member member = memberRepository.findById(partyRegisterRequest.memberId())
-				.orElseThrow(() -> new EntityNotFoundException("사용자 아이디에 문제가 발생했습니다."));
+		Member member = getMemberEntity(partyRegisterRequest.memberId());
 		PartyMember partyLeader = PartyMember.builder()
 				.member(member)
 				.party(party)
@@ -46,6 +50,20 @@ public class PartyService {
 		partyMemberRepository.save(partyLeader);
 
 		return toPartyRegisterResponse(party);
+	}
+
+	@Transactional(readOnly = true)
+	public PartyGetAllResponse getAllParty(Long memberId, PartyGetRequest partyGetRequest) {
+		List<Party> parties = partyMemberRepository.findAllByMember(getMemberEntity(memberId)).stream()
+				.map(PartyMember::getParty)
+				.toList();
+
+		return toPartyGetAllResponse(parties);
+	}
+
+	private Member getMemberEntity(Long memberId) {
+		return memberRepository.findById(memberId)
+				.orElseThrow(() -> new EntityNotFoundException("사용자 아이디에 문제가 발생했습니다."));
 	}
 
 }

--- a/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
@@ -1,6 +1,11 @@
 package org.prgrms.wumo.global.mapper;
 
+import java.util.List;
+
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.dto.response.PartyGetAllResponse;
+import org.prgrms.wumo.domain.party.dto.response.PartyGetDetailResponse;
+import org.prgrms.wumo.domain.party.dto.response.PartyGetResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
 import org.prgrms.wumo.domain.party.model.Party;
 
@@ -23,6 +28,24 @@ public class PartyMapper {
 
 	public static PartyRegisterResponse toPartyRegisterResponse(Party party) {
 		return new PartyRegisterResponse(party.getId());
+	}
+
+	public static PartyGetAllResponse toPartyGetAllResponse(List<Party> parties) {
+		List<PartyGetResponse> partyGetResponses = parties.stream()
+				.map(party -> new PartyGetResponse(party.getId(), party.getName(), party.getCoverImage()))
+				.toList();
+		return new PartyGetAllResponse(partyGetResponses);
+	}
+
+	public static PartyGetDetailResponse toPartyGetDetailResponse(Party party) {
+		return new PartyGetDetailResponse(
+				party.getId(),
+				party.getName(),
+				party.getStartDate(),
+				party.getEndDate(),
+				party.getDescription(),
+				party.getCoverImage()
+		);
 	}
 
 }

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.party.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -15,6 +16,7 @@ import org.prgrms.wumo.MysqlTestContainer;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.service.PartyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -36,6 +38,9 @@ class PartyControllerTest extends MysqlTestContainer {
 
 	@Autowired
 	private ObjectMapper objectMapper;
+
+	@Autowired
+	private PartyService partyService;
 
 	@Autowired
 	private MemberRepository memberRepository;
@@ -63,16 +68,7 @@ class PartyControllerTest extends MysqlTestContainer {
 	@DisplayName("모임을 생성할 수 있다.")
 	void registerParty() throws Exception {
 		//given
-		PartyRegisterRequest partyRegisterRequest = new PartyRegisterRequest(
-				"오예스 워크샵",
-				LocalDateTime.now(),
-				LocalDateTime.now().plusDays(1),
-				"팀 설립 기념 워크샵",
-				"https://~.jpeg",
-				"1234",
-				member.getId(),
-				"총무"
-		);
+		PartyRegisterRequest partyRegisterRequest = getPartyRegisterRequest();
 
 		//when
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/party")
@@ -84,6 +80,41 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(status().isCreated())
 				.andExpect(jsonPath("$.id").isNotEmpty())
 				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("사용자의 모임 목록을 조회할 수 있다.")
+	void getAllParty() throws Exception {
+		//given
+		partyService.registerParty(getPartyRegisterRequest());
+
+		//when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/party/members/{memberId}", member.getId())
+				.param("cursorId", (String)null)
+				.param("pageSize", "5"));
+
+		//then
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.party").isArray())
+				.andExpect(jsonPath("$.party").isNotEmpty())
+				.andExpect(jsonPath("$.party[0].id").isNotEmpty())
+				.andExpect(jsonPath("$.party[0].name").isNotEmpty())
+				.andExpect(jsonPath("$.party[0].coverImage").isNotEmpty())
+				.andDo(print());
+	}
+
+	private PartyRegisterRequest getPartyRegisterRequest() {
+		return new PartyRegisterRequest(
+				"오예스 워크샵",
+				LocalDateTime.now(),
+				LocalDateTime.now().plusDays(1),
+				"팀 설립 기념 워크샵",
+				"https://~.jpeg",
+				"1234",
+				member.getId(),
+				"총무"
+		);
 	}
 
 }


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 사용자 기준 모임 목록 조회 기능 구현

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- QueryDSL을 통한 커서 페이지네이션은 기능 개발이 끝난 후에 작업 예정입니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-154], [WUMO-155]

[WUMO-154]: https://shoekream.atlassian.net/browse/WUMO-154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-155]: https://shoekream.atlassian.net/browse/WUMO-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ