### PR TITLE
[WUMO-39] Party 상세 조회 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
@@ -55,7 +55,7 @@ public class PartyController {
 	public ResponseEntity<PartyGetDetailResponse> getParty(
 			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId
 	) {
-		return ResponseEntity.ok(null);
+		return ResponseEntity.ok(partyService.getParty(partyId));
 	}
 
 	@PatchMapping("/{partyId}")

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -2,6 +2,7 @@ package org.prgrms.wumo.domain.party.service;
 
 import static org.prgrms.wumo.global.mapper.PartyMapper.toParty;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetAllResponse;
+import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetDetailResponse;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyRegisterResponse;
 
 import java.util.List;
@@ -13,6 +14,7 @@ import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyGetRequest;
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
 import org.prgrms.wumo.domain.party.dto.response.PartyGetAllResponse;
+import org.prgrms.wumo.domain.party.dto.response.PartyGetDetailResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
@@ -61,9 +63,19 @@ public class PartyService {
 		return toPartyGetAllResponse(parties);
 	}
 
+	@Transactional(readOnly = true)
+	public PartyGetDetailResponse getParty(Long partyId) {
+		return toPartyGetDetailResponse(getPartyEntity(partyId));
+	}
+
 	private Member getMemberEntity(Long memberId) {
 		return memberRepository.findById(memberId)
 				.orElseThrow(() -> new EntityNotFoundException("사용자 아이디에 문제가 발생했습니다."));
+	}
+
+	private Party getPartyEntity(Long partyId) {
+		return partyRepository.findById(partyId)
+				.orElseThrow(() -> new EntityNotFoundException("일치하는 모임이 없습니다."));
 	}
 
 }

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -25,6 +25,7 @@ import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
 import org.prgrms.wumo.domain.party.dto.response.PartyGetAllResponse;
+import org.prgrms.wumo.domain.party.dto.response.PartyGetDetailResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
@@ -195,4 +196,46 @@ class PartyServiceTest {
 		}
 
 	}
+
+	@Nested
+	@DisplayName("getParty 메소드는 조회시")
+	class GetParty {
+
+		@Test
+		@DisplayName("모임의 상세 정보를 반환한다.")
+		void success() {
+			//mocking
+			given(partyRepository.findById(party.getId()))
+					.willReturn(Optional.of(party));
+
+			//when
+			PartyGetDetailResponse myParty = partyService.getParty(party.getId());
+
+			//then
+			assertThat(myParty.id()).isEqualTo(party.getId());
+			assertThat(myParty.name()).isEqualTo(party.getName());
+			assertThat(myParty.startDate()).isEqualTo(party.getStartDate());
+			assertThat(myParty.endDate()).isEqualTo(party.getEndDate());
+			assertThat(myParty.description()).isEqualTo(party.getDescription());
+			assertThat(myParty.coverImage()).isEqualTo(party.getCoverImage());
+
+			then(partyRepository)
+					.should()
+					.findById(party.getId());
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 모임이면 예외가 발생한다.")
+		void failed() {
+			//mocking
+			given(partyRepository.findById(party.getId()))
+					.willReturn(Optional.empty());
+
+			//when
+			//then
+			Assertions.assertThrows(EntityNotFoundException.class, () -> partyService.getParty(party.getId()));
+		}
+
+	}
+
 }


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 모임(Party) 상세 조회 기능 구현 및 테스트

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 모임 CRUD가 모두 구현된 뒤에 Authencation에서 memberId를 가져오는 방법으로 변경 예정입니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-156], [WUMO-157]

[WUMO-156]: https://shoekream.atlassian.net/browse/WUMO-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-157]: https://shoekream.atlassian.net/browse/WUMO-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ