### PR TITLE
[WUMO-35] Party 삭제 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
@@ -72,7 +72,8 @@ public class PartyController {
 	public ResponseEntity<Void> deleteParty(
 			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId
 	) {
-		return ResponseEntity.ok(null);
+		partyService.deleteParty(partyId);
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
@@ -25,16 +25,17 @@ public record PartyRegisterRequest(
 		@Schema(description = "종료일", example = "2023-02-22", required = true)
 		LocalDateTime endDate,
 
+		@NotBlank(message = "모임 설명은 필수 입력사항입니다.")
 		@Length(max = 255, message = "모임 설명은 {max}자를 초과할 수 없습니다.")
 		@Schema(description = "모임 설명", example = "팀 설립 기념 워크샵", required = true)
 		String description,
 
 		@Length(max = 255, message = "이미지 경로는 {max}자를 초과할 수 없습니다.")
-		@Schema(description = "이미지 경로", example = "https://~.jpeg", required = true)
+		@Schema(description = "이미지 경로", example = "https://~.jpeg", required = false)
 		String coverImage,
 
 		@Length(min = 4, max = 4, message = "비밀번호는 {min}자리가 필요합니다.")
-		@Schema(description = "입장 비밀번호", example = "1234", required = true)
+		@Schema(description = "입장 비밀번호", example = "1234", required = false)
 		String password,
 
 		@NotNull(message = "모임 생성 사용자 식별자는 필수 입력사항입니다.")

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
@@ -3,11 +3,18 @@ package org.prgrms.wumo.domain.party.repository;
 import java.util.List;
 
 import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long> {
 
 	List<PartyMember> findAllByMember(Member member);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM PartyMember pm WHERE pm.party = :party")
+	void deleteAllByParty(Party party);
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -63,6 +63,13 @@ public class PartyService {
 		return toPartyGetAllResponse(parties);
 	}
 
+	@Transactional
+	public void deleteParty(Long partyId) {
+		Party party = getPartyEntity(partyId);
+		partyMemberRepository.deleteAllByParty(party);
+		partyRepository.delete(party);
+	}
+
 	@Transactional(readOnly = true)
 	public PartyGetDetailResponse getParty(Long partyId) {
 		return toPartyGetDetailResponse(getPartyEntity(partyId));

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -122,8 +122,8 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id").value(partyRegisterResponse.id()))
 				.andExpect(jsonPath("$.name").value(partyRegisterRequest.name()))
-				.andExpect(jsonPath("$.startDate").isNotEmpty())	// 소수점 표기 기준이 달라 값이 있는지만 검
-				.andExpect(jsonPath("$.endDate").isNotEmpty())		// 이외 동일
+				.andExpect(jsonPath("$.startDate").isNotEmpty())	// 소수점 표기 기준이 달라 값이 있는지만 검증
+				.andExpect(jsonPath("$.endDate").isNotEmpty())		// 위와 동일
 				.andExpect(jsonPath("$.description").value(partyRegisterRequest.description()))
 				.andExpect(jsonPath("$.coverImage").value(partyRegisterRequest.coverImage()))
 				.andDo(print());

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.party.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -121,10 +122,26 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id").value(partyRegisterResponse.id()))
 				.andExpect(jsonPath("$.name").value(partyRegisterRequest.name()))
-				.andExpect(jsonPath("$.startDate").isNotEmpty())	// 소수점 표기 기준이 달라 값이 있는지만 검증
+				.andExpect(jsonPath("$.startDate").isNotEmpty())	// 소수점 표기 기준이 달라 값이 있는지만 검
 				.andExpect(jsonPath("$.endDate").isNotEmpty())		// 이외 동일
 				.andExpect(jsonPath("$.description").value(partyRegisterRequest.description()))
 				.andExpect(jsonPath("$.coverImage").value(partyRegisterRequest.coverImage()))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("특정 모임을 삭제할 수 있다.")
+	void deleteParty() throws Exception {
+		//given
+		PartyRegisterRequest partyRegisterRequest = getPartyRegisterRequest();
+		PartyRegisterResponse partyRegisterResponse = partyService.registerParty(partyRegisterRequest);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/party/{partyId}", partyRegisterResponse.id()));
+
+		//then
+		resultActions
+				.andExpect(status().isOk())
 				.andDo(print());
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -238,4 +238,41 @@ class PartyServiceTest {
 
 	}
 
+	@Nested
+	@DisplayName("deleteParty 메소드는 삭제시")
+	class DeleteParty {
+
+		@Test
+		@DisplayName("식별자가 일치하는 모임을 삭제한다.")
+		void success() {
+			//mocking
+			given(partyRepository.findById(party.getId()))
+					.willReturn(Optional.of(party));
+
+			//when
+			partyService.deleteParty(party.getId());
+
+			//then
+			then(partyRepository)
+					.should()
+					.findById(party.getId());
+			then(partyRepository)
+					.should()
+					.delete(party);
+		}
+
+		@Test
+		@DisplayName("존재하지 않는 모임이면 예외가 발생한다.")
+		void failed() {
+			//mocking
+			given(partyRepository.findById(party.getId()))
+					.willReturn(Optional.empty());
+
+			//when
+			//then
+			Assertions.assertThrows(EntityNotFoundException.class, () -> partyService.deleteParty(party.getId()));
+		}
+
+	}
+
 }


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 모임(Party) 삭제 기능 구현 및 테스트

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 지난번 PR 중점 사항과 마찬가지로 로그인 된 사용자 검증은 전체 기능 개발 완료 후 적용 예정입니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-161], [WUMO-162]

[WUMO-161]: https://shoekream.atlassian.net/browse/WUMO-161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-162]: https://shoekream.atlassian.net/browse/WUMO-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ