### PR TITLE
[WUMO-46] Location 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/location/api/LocationController.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/api/LocationController.java
@@ -50,7 +50,7 @@ public class LocationController {
 	@Operation(summary = "후보장소 목록 조회")
 	public ResponseEntity<LocationGetAllResponse> getAllLocation(
 			@Valid LocationGetAllRequest locationGetAllRequest) {
-		return ResponseEntity.ok(null);
+		return ResponseEntity.ok(locationService.getAllLocations(locationGetAllRequest));
 	}
 
 	@PatchMapping

--- a/src/main/java/org/prgrms/wumo/domain/location/dto/request/LocationGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/dto/request/LocationGetAllRequest.java
@@ -15,7 +15,7 @@ public record LocationGetAllRequest(
 		int pageSize,
 
 		@NotNull
-		@Schema(description = "후보 장소들이 속한 Party 식별자", required = true, example = "1")
+		@Schema(description = "후보 장소들이 속한 모임 식별자", required = true, example = "1")
 		Long partyId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/dto/request/LocationGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/dto/request/LocationGetAllRequest.java
@@ -12,6 +12,10 @@ public record LocationGetAllRequest(
 		@NotNull
 		@Positive(message = "page size는 0 또는 음수일 수 없습니다.")
 		@Schema(description = "페이지 사이즈", required = true, example = "5")
-		int pageSize
+		int pageSize,
+
+		@NotNull
+		@Schema(description = "후보 장소들이 속한 Party 식별자", required = true, example = "1")
+		Long partyId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/dto/response/LocationGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/dto/response/LocationGetAllResponse.java
@@ -6,6 +6,9 @@ import java.util.List;
 @Schema(name = "후보장소 목록 조회 응답 정보")
 public record LocationGetAllResponse(
 		@Schema(description = "모임의 후보장소들", required = true)
-		List<LocationGetResponse> locations
+		List<LocationGetResponse> locations,
+
+		@Schema(description = "마지막으로 조회 한 후보 장소 식별자", required = true)
+		Long lastId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
@@ -8,5 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
-	List<Location> findAllByPartyId(Long partyId);
+	List<Location> findFirst5ByPartyId(Long partyId);
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
@@ -1,9 +1,12 @@
 package org.prgrms.wumo.domain.location.repository;
 
+import java.util.List;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
+
+	List<Location> findAllByPartyId(Long partyId);
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
@@ -3,10 +3,12 @@ package org.prgrms.wumo.domain.location.repository;
 import java.util.List;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long> {
 
-	List<Location> findFirst5ByPartyId(Long partyId);
+	@Query(value = "SELECT * FROM location WHERE party_id = :partyId AND id > :cursorId LIMIT :pageSize", nativeQuery = true)
+	List<Location> findAllByPartyIdAndCursorIdLimitPageSize(Long partyId, Long cursorId, int pageSize);
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
+import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,6 +25,10 @@ public class LocationService {
 
 	@Transactional(readOnly = true)
 	public LocationGetResponse getLocation(Long locationId){
-		return toLocationGetResponse(locationRepository.findById(locationId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보 장소입니다")));
+		return toLocationGetResponse(getLocationEntity(locationId));
+	}
+
+	private Location getLocationEntity(Long locationId){
+		return locationRepository.findById(locationId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보 장소입니다"));
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -1,8 +1,10 @@
 package org.prgrms.wumo.domain.location.service;
 
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocation;
+import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetAllResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationRegisterResponse;
+import java.util.List;
 import javax.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
@@ -12,7 +14,6 @@ import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
-import org.prgrms.wumo.global.mapper.LocationMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,14 +35,8 @@ public class LocationService {
 	// TODO queryDSL 이용, 커서 기반 페이지네이션으로 변경
 	@Transactional(readOnly = true)
 	public LocationGetAllResponse getAllLocations(LocationGetAllRequest locationGetAllRequest) {
-		return new LocationGetAllResponse(
-				locationRepository
-						.findAllByPartyId(locationGetAllRequest.partyId())
-						.stream()
-						.map(LocationMapper::toLocationGetResponse)
-						.toList(),
-				10L
-		);
+		List<Location> locations = locationRepository.findFirst5ByPartyId(locationGetAllRequest.partyId());
+		return toLocationGetAllResponse(locations, locationGetAllRequest.cursorId());
 	}
 
 	private Location getLocationEntity(Long locationId) {

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -1,17 +1,20 @@
 package org.prgrms.wumo.domain.location.service;
 
+import static org.prgrms.wumo.global.mapper.LocationMapper.toLocation;
+import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
+import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationRegisterResponse;
 import javax.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
+import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.global.mapper.LocationMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocation;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationRegisterResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -19,16 +22,29 @@ public class LocationService {
 	private final LocationRepository locationRepository;
 
 	@Transactional
-	public LocationRegisterResponse registerLocation(LocationRegisterRequest locationRegisterRequest){
+	public LocationRegisterResponse registerLocation(LocationRegisterRequest locationRegisterRequest) {
 		return toLocationRegisterResponse(locationRepository.save(toLocation(locationRegisterRequest)));
 	}
 
 	@Transactional(readOnly = true)
-	public LocationGetResponse getLocation(Long locationId){
+	public LocationGetResponse getLocation(Long locationId) {
 		return toLocationGetResponse(getLocationEntity(locationId));
 	}
 
-	private Location getLocationEntity(Long locationId){
+	// TODO queryDSL 이용, 커서 기반 페이지네이션으로 변경
+	@Transactional(readOnly = true)
+	public LocationGetAllResponse getAllLocations(LocationGetAllRequest locationGetAllRequest) {
+		return new LocationGetAllResponse(
+				locationRepository
+						.findAllByPartyId(locationGetAllRequest.partyId())
+						.stream()
+						.map(LocationMapper::toLocationGetResponse)
+						.toList(),
+				10L
+		);
+	}
+
+	private Location getLocationEntity(Long locationId) {
 		return locationRepository.findById(locationId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보 장소입니다"));
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -35,8 +35,9 @@ public class LocationService {
 	// TODO queryDSL 이용, 커서 기반 페이지네이션으로 변경
 	@Transactional(readOnly = true)
 	public LocationGetAllResponse getAllLocations(LocationGetAllRequest locationGetAllRequest) {
-		List<Location> locations = locationRepository.findFirst5ByPartyId(locationGetAllRequest.partyId());
-		return toLocationGetAllResponse(locations, locationGetAllRequest.cursorId());
+		List<Location> locations = locationRepository.findAllByPartyIdAndCursorIdLimitPageSize(locationGetAllRequest.partyId(),
+				locationGetAllRequest.cursorId(), locationGetAllRequest.pageSize());
+		return toLocationGetAllResponse(locations, locationGetAllRequest.cursorId() + locationGetAllRequest.pageSize());
 	}
 
 	private Location getLocationEntity(Long locationId) {

--- a/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
@@ -48,9 +48,9 @@ public class LocationMapper {
 		);
 	}
 
-	public static LocationGetAllResponse toLocationGetAllResponse(List<Location> locations, Long cursorId){
+	public static LocationGetAllResponse toLocationGetAllResponse(List<Location> locations, Long lastId){
 		return new LocationGetAllResponse(
-				locations.stream().map(LocationMapper::toLocationGetResponse).toList(), cursorId
+				locations.stream().map(LocationMapper::toLocationGetResponse).toList(), lastId
 		);
 	}
 }

--- a/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
@@ -1,6 +1,8 @@
 package org.prgrms.wumo.global.mapper;
 
+import java.util.List;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
+import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
 import org.prgrms.wumo.domain.location.model.Location;
@@ -43,6 +45,12 @@ public class LocationMapper {
 				location.getCategory(),
 				// TODO Route 의 코드가 추가되면 route.getId()로 대체
 				1L
+		);
+	}
+
+	public static LocationGetAllResponse toLocationGetAllResponse(List<Location> locations, Long cursorId){
+		return new LocationGetAllResponse(
+				locations.stream().map(LocationMapper::toLocationGetResponse).toList(), cursorId
 		);
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/location/LocationTestUtils.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/LocationTestUtils.java
@@ -1,0 +1,63 @@
+package org.prgrms.wumo.domain.location;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+
+public class LocationTestUtils {
+	float longitude1 = 127.028f;
+	float latitude1 = 37.497f;
+	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);
+
+	Location location1 = Location.builder()
+				.id(1L).image("http://programmers_gangnam_image.com")
+				.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
+				.latitude(latitude1).longitude(longitude1)
+				.address("강남역 2번출구").visitDate(dayToVisit)
+				.category(Category.STUDY).name("프로그래머스 강남 교육장")
+				.spending(3000).expectedCost(4000)
+			.partyId(1L)
+				.build();
+
+	Location location2 = Location.builder()
+				.id(2L).image("http://grepp_image")
+				.description("그렙!!")
+				.latitude(latitude1).longitude(longitude1)
+				.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
+			.visitDate(dayToVisit)
+				.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
+				.spending(2000).expectedCost(5000)
+			.partyId(1L)
+				.build();
+
+	Location location3 = Location.builder()
+				.id(3L).image("http://gang_name_station_starbucks")
+				.description("하태하태 강남역 스벅 강남 R점")
+				.latitude(latitude1).longitude(longitude1)
+				.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+				.category(Category.COFFEE).name("강남역 R점")
+				.spending(6000).expectedCost(5500)
+			.partyId(1L)
+				.build();
+
+	public List<Location> getLocations(){
+		return List.of(location1, location2, location3);
+	}
+
+	public Location getLocation(){
+		return location1;
+	}
+
+	public Float getLatitude1(){
+		return latitude1;
+	}
+
+	public Float getLongitude1(){
+		return longitude1;
+	}
+
+	public LocalDateTime getDayToVisit(){
+		return dayToVisit;
+	}
+}

--- a/src/test/java/org/prgrms/wumo/domain/location/LocationTestUtils.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/LocationTestUtils.java
@@ -6,58 +6,97 @@ import org.prgrms.wumo.domain.location.model.Category;
 import org.prgrms.wumo.domain.location.model.Location;
 
 public class LocationTestUtils {
-	float longitude1 = 127.028f;
-	float latitude1 = 37.497f;
+	final float longitude1 = 127.028f;
+	final float latitude1 = 37.497f;
 	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);
 
 	Location location1 = Location.builder()
-				.id(1L).image("http://programmers_gangnam_image.com")
-				.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
-				.latitude(latitude1).longitude(longitude1)
-				.address("강남역 2번출구").visitDate(dayToVisit)
-				.category(Category.STUDY).name("프로그래머스 강남 교육장")
-				.spending(3000).expectedCost(4000)
+			.id(1L).image("http://programmers_gangnam_image.com")
+			.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
+			.latitude(latitude1).longitude(longitude1)
+			.address("강남역 2번출구").visitDate(dayToVisit)
+			.category(Category.STUDY).name("프로그래머스 강남 교육장")
+			.spending(3000).expectedCost(4000)
 			.partyId(1L)
-				.build();
+			.build();
 
 	Location location2 = Location.builder()
-				.id(2L).image("http://grepp_image")
-				.description("그렙!!")
-				.latitude(latitude1).longitude(longitude1)
-				.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
+			.id(2L).image("http://grepp_image")
+			.description("그렙!!")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
 			.visitDate(dayToVisit)
-				.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
-				.spending(2000).expectedCost(5000)
+			.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
+			.spending(2000).expectedCost(5000)
 			.partyId(1L)
-				.build();
+			.build();
 
 	Location location3 = Location.builder()
-				.id(3L).image("http://gang_name_station_starbucks")
-				.description("하태하태 강남역 스벅 강남 R점")
-				.latitude(latitude1).longitude(longitude1)
-				.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
-				.category(Category.COFFEE).name("강남역 R점")
-				.spending(6000).expectedCost(5500)
+			.id(3L).image("http://gang_name_station_starbucks")
+			.description("하태하태 강남역 스벅 강남 R점")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+			.category(Category.COFFEE).name("강남역 R점")
+			.spending(6000).expectedCost(5500)
 			.partyId(1L)
-				.build();
+			.build();
 
-	public List<Location> getLocations(){
-		return List.of(location1, location2, location3);
+	Location location4 = Location.builder()
+			.id(4L).image("http://four_image")
+			.description("4번째 핫플")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+			.category(Category.COFFEE).name("강남역 R점")
+			.spending(6000).expectedCost(5500)
+			.partyId(1L)
+			.build();
+
+	Location location5 = Location.builder()
+			.id(5L).image("http://five_image.com")
+			.description("5번 째 핫풀")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+			.category(Category.COFFEE).name("강남역 R점")
+			.spending(6000).expectedCost(5500)
+			.partyId(2L)
+			.build();
+
+	Location location6 = Location.builder()
+			.id(6L).image("http://six_image.com")
+			.description("6번째 핫플")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+			.category(Category.COFFEE).name("강남역 R점")
+			.spending(6000).expectedCost(5500)
+			.partyId(1L)
+			.build();
+	Location location7 = Location.builder()
+			.id(7L).image("http://seven_image")
+			.description("7번째 핫플")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+			.category(Category.COFFEE).name("강남역 R점")
+			.spending(6000).expectedCost(5500)
+			.partyId(1L)
+			.build();
+
+	public List<Location> getLocations() {
+		return List.of(location1, location2, location3, location4, location5, location6, location7);
 	}
 
-	public Location getLocation(){
+	public Location getLocation() {
 		return location1;
 	}
 
-	public Float getLatitude1(){
+	public Float getLatitude1() {
 		return latitude1;
 	}
 
-	public Float getLongitude1(){
+	public Float getLongitude1() {
 		return longitude1;
 	}
 
-	public LocalDateTime getDayToVisit(){
+	public LocalDateTime getDayToVisit() {
 		return dayToVisit;
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
@@ -6,14 +6,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgrms.wumo.MysqlTestContainer;
+import org.prgrms.wumo.domain.location.LocationTestUtils;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
 import org.prgrms.wumo.domain.location.model.Category;
-import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -39,39 +37,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 	private ObjectMapper objectMapper;
 
 	// GIVEN
-	float longitude1 = 127.028f;
-	float latitude1 = 37.497f;
-	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);
-
-	Location location1 = Location.builder()
-			.id(1L).image("http://programmers_gangnam_image.com")
-			.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
-			.latitude(latitude1).longitude(longitude1)
-			.address("강남역 2번출구").visitDate(dayToVisit)
-			.category(Category.STUDY).name("프로그래머스 강남 교육장")
-			.spending(3000).expectedCost(4000).partyId(1L)
-			.build();
-
-	Location location2 = Location.builder()
-			.id(2L).image("http://grepp_image")
-			.description("그렙!!")
-			.latitude(latitude1).longitude(longitude1)
-			.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
-			.visitDate(dayToVisit)
-			.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
-			.spending(2000).expectedCost(5000)
-			.partyId(1L)
-			.build();
-
-	Location location3 = Location.builder()
-			.id(3L).image("http://gang_name_station_starbucks")
-			.description("하태하태 강남역 스벅 강남 R점")
-			.latitude(latitude1).longitude(longitude1)
-			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
-			.category(Category.COFFEE).name("강남역 R점")
-			.spending(6000).expectedCost(5500)
-			.partyId(1L)
-			.build();
+	LocationTestUtils locationTestUtils = new LocationTestUtils();
 
 	@Test
 	@DisplayName("후보 장소를 등록한다")
@@ -81,12 +47,12 @@ public class LocationControllerTest extends MysqlTestContainer {
 				= new LocationRegisterRequest(
 				"프로그래머스 강남 교육장",
 				"강남역 2번출구",
-				latitude1,
-				longitude1,
+				locationTestUtils.getLatitude1(),
+				locationTestUtils.getLongitude1(),
 				"http://programmers_gangnam_image.com",
 				Category.STUDY,
 				"이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....",
-				dayToVisit
+				locationTestUtils.getDayToVisit()
 				, 4000,
 				1L
 		);
@@ -114,7 +80,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 	@DisplayName("후보 장소 하나를 상세 조회할 수 있다.")
 	void getLocationTest() throws Exception {
 		// Given
-		locationRepository.save(location1);
+		locationRepository.save(locationTestUtils.getLocation());
 
 		// When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/locations/{locationId}", 1));
@@ -124,23 +90,23 @@ public class LocationControllerTest extends MysqlTestContainer {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id").value(1))
 				.andExpect(jsonPath("$.name").value("프로그래머스 강남 교육장"))
-				.andExpect(jsonPath("$.latitude").value(latitude1))
-				.andExpect(jsonPath("$.longitude").value(longitude1))
+				.andExpect(jsonPath("$.latitude").value(locationTestUtils.getLatitude1()))
+				.andExpect(jsonPath("$.longitude").value(locationTestUtils.getLongitude1()))
 				.andDo(print());
 	}
 
 	@Test
-	@DisplayName("후보 장소 전체를 조회할 수 있다.")
+	@DisplayName(" 특정 모임 내의 후보 장소 전체를 조회할 수 있다.")
 	void getAllLocationTest() throws Exception {
 		// Given
-		List<Location> locations = List.of(location1, location2, location3);
-		locationRepository.saveAll(locations);
+		// List<Location> locations = List.of(location1, location2, location3);
+		locationRepository.saveAll(locationTestUtils.getLocations());
 
 		// When
 		ResultActions resultActions = mockMvc.perform(
 				get("/api/v1/locations")
 						.param("cursorId", (String)null)
-						.param("pageSize", "10")
+						.param("pageSize", "5")
 						.param("partyId", "1")
 		);
 
@@ -150,8 +116,8 @@ public class LocationControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.locations").isArray())
 				.andExpect(jsonPath("$.locations").isNotEmpty())
 				.andExpect(jsonPath("$.locations[0].id").value(1))
-				.andExpect(jsonPath("$.locations[0].latitude").value(latitude1))
-				.andExpect(jsonPath("$.locations[0].longitude").value(longitude1))
+				.andExpect(jsonPath("$.locations[0].latitude").value(locationTestUtils.getLatitude1()))
+				.andExpect(jsonPath("$.locations[0].longitude").value(locationTestUtils.getLongitude1()))
 				.andExpect(jsonPath("$.locations[0].spending").value(3000))
 				.andExpect(jsonPath("$.locations[0].expectedCost").value(4000))
 				.andDo(print());

--- a/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
@@ -105,7 +105,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 		// When
 		ResultActions resultActions = mockMvc.perform(
 				get("/api/v1/locations")
-						.param("cursorId", (String)null)
+						.param("cursorId", "0" )
 						.param("pageSize", "5")
 						.param("partyId", "1")
 		);

--- a/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
@@ -37,6 +37,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 	@Autowired
 	private ObjectMapper objectMapper;
 
+	// GIVEN
 	float longitude = 127.028f;
 	float latitude = 37.497f;
 	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);

--- a/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
@@ -5,7 +5,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgrms.wumo.MysqlTestContainer;
@@ -20,7 +22,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -38,18 +39,39 @@ public class LocationControllerTest extends MysqlTestContainer {
 	private ObjectMapper objectMapper;
 
 	// GIVEN
-	float longitude = 127.028f;
-	float latitude = 37.497f;
+	float longitude1 = 127.028f;
+	float latitude1 = 37.497f;
 	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);
 
-	Location location = Location.builder()
-				.id(1L).image("http://programmers_gangnam_image.com")
-				.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
-				.latitude(latitude).longitude(longitude)
-				.address("강남역 2번출구").visitDate(dayToVisit)
-				.category(Category.STUDY).name("프로그래머스 강남 교육장")
-				.spending(3000).expectedCost(4000).partyId(1L)
-				.build();
+	Location location1 = Location.builder()
+			.id(1L).image("http://programmers_gangnam_image.com")
+			.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
+			.latitude(latitude1).longitude(longitude1)
+			.address("강남역 2번출구").visitDate(dayToVisit)
+			.category(Category.STUDY).name("프로그래머스 강남 교육장")
+			.spending(3000).expectedCost(4000).partyId(1L)
+			.build();
+
+	Location location2 = Location.builder()
+			.id(2L).image("http://grepp_image")
+			.description("그렙!!")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
+			.visitDate(dayToVisit)
+			.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
+			.spending(2000).expectedCost(5000)
+			.partyId(1L)
+			.build();
+
+	Location location3 = Location.builder()
+			.id(3L).image("http://gang_name_station_starbucks")
+			.description("하태하태 강남역 스벅 강남 R점")
+			.latitude(latitude1).longitude(longitude1)
+			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+			.category(Category.COFFEE).name("강남역 R점")
+			.spending(6000).expectedCost(5500)
+			.partyId(1L)
+			.build();
 
 	@Test
 	@DisplayName("후보 장소를 등록한다")
@@ -59,8 +81,8 @@ public class LocationControllerTest extends MysqlTestContainer {
 				= new LocationRegisterRequest(
 				"프로그래머스 강남 교육장",
 				"강남역 2번출구",
-				latitude,
-				longitude,
+				latitude1,
+				longitude1,
 				"http://programmers_gangnam_image.com",
 				Category.STUDY,
 				"이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....",
@@ -92,7 +114,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 	@DisplayName("후보 장소 하나를 상세 조회할 수 있다.")
 	void getLocationTest() throws Exception {
 		// Given
-		locationRepository.save(location);
+		locationRepository.save(location1);
 
 		// When
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/locations/{locationId}", 1));
@@ -102,8 +124,36 @@ public class LocationControllerTest extends MysqlTestContainer {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id").value(1))
 				.andExpect(jsonPath("$.name").value("프로그래머스 강남 교육장"))
-				.andExpect(jsonPath("$.latitude").value(latitude))
-				.andExpect(jsonPath("$.longitude").value(longitude))
+				.andExpect(jsonPath("$.latitude").value(latitude1))
+				.andExpect(jsonPath("$.longitude").value(longitude1))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("후보 장소 전체를 조회할 수 있다.")
+	void getAllLocationTest() throws Exception {
+		// Given
+		List<Location> locations = List.of(location1, location2, location3);
+		locationRepository.saveAll(locations);
+
+		// When
+		ResultActions resultActions = mockMvc.perform(
+				get("/api/v1/locations")
+						.param("cursorId", (String)null)
+						.param("pageSize", "10")
+						.param("partyId", "1")
+		);
+
+		// Then
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.locations").isArray())
+				.andExpect(jsonPath("$.locations").isNotEmpty())
+				.andExpect(jsonPath("$.locations[0].id").value(1))
+				.andExpect(jsonPath("$.locations[0].latitude").value(latitude1))
+				.andExpect(jsonPath("$.locations[0].longitude").value(longitude1))
+				.andExpect(jsonPath("$.locations[0].spending").value(3000))
+				.andExpect(jsonPath("$.locations[0].expectedCost").value(4000))
 				.andDo(print());
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.location.LocationTestUtils;
 import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
@@ -36,40 +35,8 @@ public class LocationServiceTest {
 	LocationRepository locationRepository;
 
 	// GIVEN
-	float longitude1 = 127.028f;
-	float latitude1 = 37.497f;
-	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);
 
-	Location location1 = Location.builder()
-				.id(1L).image("http://programmers_gangnam_image.com")
-				.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
-				.latitude(latitude1).longitude(longitude1)
-				.address("강남역 2번출구").visitDate(dayToVisit)
-				.category(Category.STUDY).name("프로그래머스 강남 교육장")
-				.spending(3000).expectedCost(4000)
-			.partyId(1L)
-				.build();
-
-	Location location2 = Location.builder()
-				.id(2L).image("http://grepp_image")
-				.description("그렙!!")
-				.latitude(latitude1).longitude(longitude1)
-				.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
-			.visitDate(dayToVisit)
-				.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
-				.spending(2000).expectedCost(5000)
-			.partyId(1L)
-				.build();
-
-	Location location3 = Location.builder()
-				.id(3L).image("http://gang_name_station_starbucks")
-				.description("하태하태 강남역 스벅 강남 R점")
-				.latitude(latitude1).longitude(longitude1)
-				.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
-				.category(Category.COFFEE).name("강남역 R점")
-				.spending(6000).expectedCost(5500)
-			.partyId(1L)
-				.build();
+	LocationTestUtils locationTestUtils = new LocationTestUtils();
 
 	@Nested
 	@DisplayName("registerLocation을 사용해서 ")
@@ -78,16 +45,16 @@ public class LocationServiceTest {
 		LocationRegisterRequest locationRegisterRequest
 				= new LocationRegisterRequest(
 						"프로그래머스 강남 교육장", "강남역 2번출구"
-				, latitude1, longitude1, "http://programmers_gangnam_image.com"
+				, locationTestUtils.getLatitude1(), locationTestUtils.getLongitude1(), "http://programmers_gangnam_image.com"
 				, Category.STUDY, "이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀...."
-				, dayToVisit, 4000, 1L
+				, locationTestUtils.getDayToVisit(), 4000, 1L
 		);
 
 		@Test
 		@DisplayName("후보 장소를 등록할 수 있다.")
 		void registerLocationTest(){
 			// Given
-			given(locationRepository.save(any(Location.class))).willReturn(location1);
+			given(locationRepository.save(any(Location.class))).willReturn(locationTestUtils.getLocation());
 
 			// When
 			LocationRegisterResponse locationRegisterResponse =
@@ -108,14 +75,14 @@ public class LocationServiceTest {
 		@DisplayName("후보 장소 하나를 상세 조회할 수 있다.")
 		void getOneLocationTest(){
 			// Given
-			given(locationRepository.findById(1L)).willReturn(Optional.of(location1));
+			given(locationRepository.findById(1L)).willReturn(Optional.of(locationTestUtils.getLocation()));
 
 			// When
 			LocationGetResponse locationGetResponse =
 					locationService.getLocation(1L);
 
 			// Then
-			assertThat(locationGetResponse).usingRecursiveComparison().isEqualTo(toLocationGetResponse(location1));
+			assertThat(locationGetResponse).usingRecursiveComparison().isEqualTo(toLocationGetResponse(locationTestUtils.getLocation()));
 		}
 
 		@Test
@@ -135,9 +102,6 @@ public class LocationServiceTest {
 	@DisplayName("getAllLocation을 사용해서 ")
 	class getAllLocations{
 		// Given
-		List<Location> locations = List.of(
-				location1, location2, location3
-		);
 
 		LocationGetAllRequest locationGetAllRequest
 				= new LocationGetAllRequest(0L, 15, 1L);
@@ -146,7 +110,7 @@ public class LocationServiceTest {
 		@DisplayName("해당 모임의 모든 후보 장소를 가져올 수 있다.")
 		void getAllLocationsTest(){
 			// Given
-			given(locationRepository.findAllByPartyId(1L)).willReturn(locations);
+			given(locationRepository.findFirst5ByPartyId(1L)).willReturn(locationTestUtils.getLocations());
 
 			// When
 			LocationGetAllResponse locationGetAllResponse = locationService.getAllLocations(locationGetAllRequest);
@@ -155,7 +119,7 @@ public class LocationServiceTest {
 			assertThat(locationGetAllResponse.locations().size()).isEqualTo(3);
 			for (int i = 0; i < 3; i++) {
 				assertThat(locationGetAllResponse.locations().get(i)).usingRecursiveComparison()
-						.isEqualTo(toLocationGetResponse(locations.get(i)));
+						.isEqualTo(toLocationGetResponse(locationTestUtils.getLocations().get(i)));
 			}
 		}
 

--- a/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import javax.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +16,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
+import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
 import org.prgrms.wumo.domain.location.model.Category;
@@ -32,17 +36,39 @@ public class LocationServiceTest {
 	LocationRepository locationRepository;
 
 	// GIVEN
-	float longitude = 127.028f;
-	float latitude = 37.497f;
+	float longitude1 = 127.028f;
+	float latitude1 = 37.497f;
 	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);
 
-	Location location = Location.builder()
+	Location location1 = Location.builder()
 				.id(1L).image("http://programmers_gangnam_image.com")
 				.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
-				.latitude(latitude).longitude(longitude)
+				.latitude(latitude1).longitude(longitude1)
 				.address("강남역 2번출구").visitDate(dayToVisit)
 				.category(Category.STUDY).name("프로그래머스 강남 교육장")
 				.spending(3000).expectedCost(4000)
+			.partyId(1L)
+				.build();
+
+	Location location2 = Location.builder()
+				.id(2L).image("http://grepp_image")
+				.description("그렙!!")
+				.latitude(latitude1).longitude(longitude1)
+				.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
+			.visitDate(dayToVisit)
+				.category(Category.STUDY).name("프로그래머스 대륭 서초 타워")
+				.spending(2000).expectedCost(5000)
+			.partyId(1L)
+				.build();
+
+	Location location3 = Location.builder()
+				.id(3L).image("http://gang_name_station_starbucks")
+				.description("하태하태 강남역 스벅 강남 R점")
+				.latitude(latitude1).longitude(longitude1)
+				.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
+				.category(Category.COFFEE).name("강남역 R점")
+				.spending(6000).expectedCost(5500)
+			.partyId(1L)
 				.build();
 
 	@Nested
@@ -52,7 +78,7 @@ public class LocationServiceTest {
 		LocationRegisterRequest locationRegisterRequest
 				= new LocationRegisterRequest(
 						"프로그래머스 강남 교육장", "강남역 2번출구"
-				, latitude, longitude, "http://programmers_gangnam_image.com"
+				, latitude1, longitude1, "http://programmers_gangnam_image.com"
 				, Category.STUDY, "이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀...."
 				, dayToVisit, 4000, 1L
 		);
@@ -61,7 +87,7 @@ public class LocationServiceTest {
 		@DisplayName("후보 장소를 등록할 수 있다.")
 		void registerLocationTest(){
 			// Given
-			given(locationRepository.save(any(Location.class))).willReturn(location);
+			given(locationRepository.save(any(Location.class))).willReturn(location1);
 
 			// When
 			LocationRegisterResponse locationRegisterResponse =
@@ -82,21 +108,14 @@ public class LocationServiceTest {
 		@DisplayName("후보 장소 하나를 상세 조회할 수 있다.")
 		void getOneLocationTest(){
 			// Given
-			given(locationRepository.findById(1L)).willReturn(Optional.of(location));
+			given(locationRepository.findById(1L)).willReturn(Optional.of(location1));
 
 			// When
 			LocationGetResponse locationGetResponse =
 					locationService.getLocation(1L);
 
 			// Then
-			assertThat(locationGetResponse.id()).isEqualTo(1L);
-			assertThat(locationGetResponse.latitude()).isEqualTo(latitude);
-			assertThat(locationGetResponse.longitude()).isEqualTo(longitude);
-			assertThat(locationGetResponse.spending()).isEqualTo(3000);
-			assertThat(locationGetResponse.expectedCost()).isEqualTo(4000);
-			assertThat(locationGetResponse.visitDate()).isEqualTo(dayToVisit);
-			assertThat(locationGetResponse.category()).isEqualTo(Category.STUDY);
-			assertThat(locationGetResponse.name()).isEqualTo("프로그래머스 강남 교육장");
+			assertThat(locationGetResponse).usingRecursiveComparison().isEqualTo(toLocationGetResponse(location1));
 		}
 
 		@Test
@@ -110,5 +129,35 @@ public class LocationServiceTest {
 					() -> locationService.getLocation(1L)
 			).isInstanceOf(EntityNotFoundException.class);
 		}
+	}
+
+	@Nested
+	@DisplayName("getAllLocation을 사용해서 ")
+	class getAllLocations{
+		// Given
+		List<Location> locations = List.of(
+				location1, location2, location3
+		);
+
+		LocationGetAllRequest locationGetAllRequest
+				= new LocationGetAllRequest(0L, 15, 1L);
+
+		@Test
+		@DisplayName("해당 모임의 모든 후보 장소를 가져올 수 있다.")
+		void getAllLocationsTest(){
+			// Given
+			given(locationRepository.findAllByPartyId(1L)).willReturn(locations);
+
+			// When
+			LocationGetAllResponse locationGetAllResponse = locationService.getAllLocations(locationGetAllRequest);
+
+			// Then
+			assertThat(locationGetAllResponse.locations().size()).isEqualTo(3);
+			for (int i = 0; i < 3; i++) {
+				assertThat(locationGetAllResponse.locations().get(i)).usingRecursiveComparison()
+						.isEqualTo(toLocationGetResponse(locations.get(i)));
+			}
+		}
+
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
@@ -31,6 +31,7 @@ public class LocationServiceTest {
 	@Mock
 	LocationRepository locationRepository;
 
+	// GIVEN
 	float longitude = 127.028f;
 	float latitude = 37.497f;
 	LocalDateTime dayToVisit = LocalDateTime.now().plusDays(10);


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

Location 목록 조회 기능 구현

### ⛏ 중점 사항

- 현재는 단순 조회기능만 구현했습니다. 추후 queryDSL을 이용한 커서 기반 페이징으로 고칠 생각입니다!
- 일단 목록 조회에서 페이지 사이즈 만큼 가져오려고 시도 했는데 JPQL 에서는 limit을 사용 못해서 페이지 사이즈 5 고정으로 가정하고 서비스 코드 작성했습니다!

### 💡 관련 이슈

- Resolved : WUMO-46