### PR TITLE
[WUMO-52] Route 등록 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
@@ -8,6 +8,7 @@ import org.prgrms.wumo.domain.route.dto.request.RouteStatusUpdateRequest;
 import org.prgrms.wumo.domain.route.dto.response.RouteGetAllResponse;
 import org.prgrms.wumo.domain.route.dto.response.RouteGetResponse;
 import org.prgrms.wumo.domain.route.dto.response.RouteRegisterResponse;
+import org.prgrms.wumo.domain.route.service.RouteService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,24 +24,28 @@ import org.springframework.web.bind.annotation.RestController;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/routes")
+@RequiredArgsConstructor
 @Tag(name = "루트 API")
 public class RouteController {
+
+	private final RouteService routeService;
 
 	@PostMapping
 	@Operation(summary = "루트에 후보지 등록")
 	public ResponseEntity<RouteRegisterResponse> registerRoute(
 		@RequestBody @Valid RouteRegisterRequest routeRegisterRequest) {
 
-		return new ResponseEntity<>(null, HttpStatus.CREATED);
+		return new ResponseEntity<>(routeService.registerRoute(routeRegisterRequest), HttpStatus.CREATED);
 	}
 
 	@GetMapping("/{routeId}")
 	@Operation(summary = "루트 상세 조회")
 	public ResponseEntity<RouteGetResponse> getRoute(
-		@PathVariable @Parameter(description = "조회할 루트 아이디") Long routeId) {
+		@PathVariable @Parameter(description = "조회할 루트 아이디") long routeId) {
 
 		return ResponseEntity.ok(null);
 	}
@@ -56,7 +61,7 @@ public class RouteController {
 	@DeleteMapping
 	@Operation(summary = "루트에서 후보지 삭제")
 	public ResponseEntity<Void> deleteRouteLocation(
-		@RequestParam @Parameter(description = "루트에서 삭제할 후보장소 아이디") Long locationId) {
+		@RequestParam @Parameter(description = "루트에서 삭제할 후보장소 아이디") long locationId) {
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteRegisterRequest.java
@@ -6,8 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "루트에 후보지 등록 요청 정보")
 public record RouteRegisterRequest(
+	@Schema(description = "이미 루트가 존재할 경우의 루트 식별자(루트를 처음 생성한다면 null)", required = false, example = "1")
+	Long routeId,
+
 	@NotNull(message = "등록할 후보지를 선택해주세요.")
 	@Schema(description = "루트에 등록할 후보지 식별자", required = true, example = "1")
-	Long locationId
+	Long locationId,
+
+	@NotNull(message = "루트를 등록할 모임을 선택해주세요.")
+	@Schema(description = "루트를 등록할 모임 식별자", required = true, example = "1")
+	Long partyId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
@@ -15,6 +15,7 @@ import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.global.audit.BaseTimeEntity;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,7 +37,15 @@ public class Route extends BaseTimeEntity {
 	@OneToOne
 	private Party party;
 
-	public void changeRoute(Location location) {
+	@Builder
+	public Route(Long id, boolean isPublic, List<Location> locations, Party party) {
+		this.id = id;
+		this.isPublic = isPublic;
+		this.locations = locations;
+		this.party = party;
+	}
+
+	public void updateLocation(Location location) {
 		if (location.getRoute() != null) {
 			location.getRoute().getLocations().remove(location);
 		}

--- a/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
@@ -38,9 +38,9 @@ public class Route extends BaseTimeEntity {
 	private Party party;
 
 	@Builder
-	public Route(Long id, boolean isPublic, List<Location> locations, Party party) {
+	public Route(Long id, List<Location> locations, Party party) {
 		this.id = id;
-		this.isPublic = isPublic;
+		this.isPublic = false;
 		this.locations = locations;
 		this.party = party;
 	}

--- a/src/main/java/org/prgrms/wumo/domain/route/repository/RouteRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/repository/RouteRepository.java
@@ -1,0 +1,7 @@
+package org.prgrms.wumo.domain.route.repository;
+
+import org.prgrms.wumo.domain.route.model.Route;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteRepository extends JpaRepository<Route, Long> {
+}

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -1,0 +1,61 @@
+package org.prgrms.wumo.domain.route.service;
+
+import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
+import static org.prgrms.wumo.global.mapper.RouteMapper.toRoute;
+import static org.prgrms.wumo.global.mapper.RouteMapper.toRouteRegisterResponse;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.prgrms.wumo.domain.route.dto.request.RouteRegisterRequest;
+import org.prgrms.wumo.domain.route.dto.response.RouteRegisterResponse;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RouteService {
+
+	private final RouteRepository routeRepository;
+	private final PartyRepository partyRepository;
+	private final PartyMemberRepository partyMemberRepository;
+	private final LocationRepository locationRepository;
+
+	public RouteRegisterResponse registerRoute(RouteRegisterRequest routeRegisterRequest) {
+		Party party = partyRepository.findById(routeRegisterRequest.partyId())
+			.orElseThrow(() -> new EntityNotFoundException("일치하는 모임이 없습니다."));
+		Location location = locationRepository.findById(routeRegisterRequest.locationId())
+			.orElseThrow(() -> new EntityNotFoundException("일치하는 후보지가 없습니다."));
+
+		validateAccess(party);
+
+		if (routeRegisterRequest.routeId() == null) {
+			Route route = routeRepository.save(toRoute(location, party));
+			return toRouteRegisterResponse(route.getId());
+		}
+
+		Route route = routeRepository.findById(routeRegisterRequest.routeId())
+			.orElseThrow(() -> new EntityNotFoundException("일치하는 루트가 없습니다."));
+		route.updateLocation(location);
+
+		return toRouteRegisterResponse(route.getId());
+	}
+
+	private void validateAccess(Party party) {
+		if (isNotPartyMember(party.getId())) {
+			throw new AccessDeniedException("잘못된 접근입니다.");
+		}
+	}
+
+	private boolean isNotPartyMember(long partyId) {
+		return !partyMemberRepository.existsByPartyIdAndMemberId(partyId, getMemberId());
+	}
+}

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -1,0 +1,27 @@
+package org.prgrms.wumo.global.mapper;
+
+import java.util.List;
+
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.route.dto.response.RouteRegisterResponse;
+import org.prgrms.wumo.domain.route.model.Route;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RouteMapper {
+
+	public static RouteRegisterResponse toRouteRegisterResponse(long routeId) {
+		return new RouteRegisterResponse(routeId);
+	}
+
+	public static Route toRoute(Location location, Party party) {
+		return Route.builder()
+			.isPublic(false)
+			.locations(List.of(location))
+			.party(party)
+			.build();
+	}
+}

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -19,7 +19,6 @@ public class RouteMapper {
 
 	public static Route toRoute(Location location, Party party) {
 		return Route.builder()
-			.isPublic(false)
 			.locations(List.of(location))
 			.party(party)
 			.build();

--- a/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
@@ -50,15 +50,7 @@ public class MemberControllerTest extends MysqlTestContainer {
 
 	@BeforeEach
 	void setup() {
-		String email = "taehee@gmail.com";
-		String nickname = "태희";
-		String password = "qwe12345";
-		Member member = Member.builder()
-			.email(email)
-			.nickname(nickname)
-			.password(password)
-			.build();
-		memberRepository.save(member);
+		Member member = memberRepository.save(getMemberData());
 		memberId = member.getId();
 
 		SecurityContext context = SecurityContextHolder.getContext();
@@ -167,5 +159,13 @@ public class MemberControllerTest extends MysqlTestContainer {
 			.andExpect(jsonPath("$.nickname").value("태희"))
 			.andExpect(jsonPath("$.profileImage").isEmpty())
 			.andDo(print());
+	}
+
+	private Member getMemberData() {
+		return Member.builder()
+			.email("taehee@gmail.com")
+			.nickname("태희")
+			.password("qwe12345")
+			.build();
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -6,8 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.BDDMockito.then;
 
 import java.util.Collections;
 import java.util.Optional;
@@ -93,7 +92,9 @@ public class MemberServiceTest {
 
 			//then
 			assertThat(result.id()).isEqualTo(1L);
-			verify(memberRepository, times(1)).save(any(Member.class));
+			then(memberRepository)
+				.should()
+				.save(any(Member.class));
 		}
 	}
 
@@ -181,8 +182,12 @@ public class MemberServiceTest {
 
 			//then
 			assertThat(result).usingRecursiveComparison().isEqualTo(wumoJwt);
-			verify(memberRepository, times(1)).findByEmail(any(Email.class));
-			verify(jwtTokenProvider, times(1)).generateToken(anyString());
+			then(memberRepository)
+				.should()
+				.findByEmail(any(Email.class));
+			then(jwtTokenProvider)
+				.should()
+				.generateToken(anyString());
 		}
 
 		@Test
@@ -245,7 +250,9 @@ public class MemberServiceTest {
 
 			//then
 			assertThat(result.nickname()).isEqualTo(member.getNickname());
-			verify(memberRepository, times(1)).findById(anyLong());
+			then(memberRepository)
+				.should()
+				.findById(anyLong());
 		}
 
 		@Test

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import javax.persistence.EntityNotFoundException;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -60,6 +61,11 @@ public class MemberServiceTest {
 			new UsernamePasswordAuthenticationToken(1L, null, Collections.EMPTY_LIST);
 
 		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
 	}
 
 	@Nested
@@ -146,7 +152,7 @@ public class MemberServiceTest {
 
 	@Nested
 	@DisplayName("login 메소드는 로그인 요청 시 ")
-	class Login {
+	class LoginMember {
 		//given
 		String email = "5yes@gmail.com";
 		String nickname = "오예스오리지널";

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.prgrms.wumo.MysqlTestContainer;
 import org.prgrms.wumo.domain.location.model.Category;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
@@ -39,7 +40,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 @AutoConfigureMockMvc
 @ActiveProfiles("test")
 @DisplayName("RouteController를 통해 ")
-public class RouteControllerTest {
+public class RouteControllerTest extends MysqlTestContainer {
 
 	private long memberId;
 	private long partyId;

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -1,0 +1,154 @@
+package org.prgrms.wumo.domain.route.api;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.prgrms.wumo.domain.route.dto.request.RouteRegisterRequest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("RouteController를 통해 ")
+public class RouteControllerTest {
+
+	private long memberId;
+	private long partyId;
+	private long locationId;
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	PartyRepository partyRepository;
+
+	@Autowired
+	LocationRepository locationRepository;
+
+	@Autowired
+	PartyMemberRepository partyMemberRepository;
+
+	@BeforeEach
+	void setup() {
+		Member member = memberRepository.save(getMemberData());
+		memberId = member.getId();
+
+		Party party = partyRepository.save(getPartyData());
+		partyId = party.getId();
+
+		Location location = locationRepository.save(getLocationData());
+		locationId = location.getId();
+
+		partyMemberRepository.save(getPartyMemberData(member, party));
+
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+			new UsernamePasswordAuthenticationToken(memberId, null, Collections.EMPTY_LIST);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@AfterEach
+	void tearDown() {
+		partyMemberRepository.deleteAll();
+		locationRepository.deleteAll();
+		partyRepository.deleteAll();
+		memberRepository.deleteAll();
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("후보지를 루트에 등록한다")
+	void register_route() throws Exception {
+		//given
+		RouteRegisterRequest routeRegisterRequest
+			= new RouteRegisterRequest(null, locationId, partyId);
+
+		//when
+		ResultActions resultActions
+			= mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/routes")
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.content(objectMapper.writeValueAsString(routeRegisterRequest)));
+
+		//then
+		resultActions
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.id").isNotEmpty())
+			.andDo(print());
+	}
+
+	private Member getMemberData() {
+		return Member.builder()
+			.email("taehee@gmail.com")
+			.nickname("태희")
+			.password("qwe12345")
+			.build();
+	}
+
+	private Party getPartyData() {
+		return Party.builder()
+			.name("제주도 한달 살기")
+			.coverImage("http://~~~.png")
+			.startDate(LocalDateTime.now())
+			.endDate(LocalDateTime.now().plusDays(1))
+			.build();
+	}
+
+	private Location getLocationData() {
+		return Location.builder()
+			.name("오예스 찜닭")
+			.latitude(12.3456F)
+			.longitude(34.5678F)
+			.address("제주시 서귀포시 서귀동")
+			.image("http://~~~.png")
+			.visitDate(LocalDateTime.now().plusDays(10))
+			.category(Category.MEAL)
+			.expectedCost(40000)
+			.partyId(partyId)
+			.build();
+	}
+
+	private PartyMember getPartyMemberData(Member member, Party party) {
+		return PartyMember.builder()
+			.member(member)
+			.party(party)
+			.role("총무")
+			.isLeader(true)
+			.build();
+	}
+}

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -88,10 +88,10 @@ public class RouteControllerTest extends MysqlTestContainer {
 
 	@AfterEach
 	void tearDown() {
-		partyMemberRepository.deleteAll();
-		locationRepository.deleteAll();
-		partyRepository.deleteAll();
-		memberRepository.deleteAll();
+		partyMemberRepository.deleteById(partyId);
+		locationRepository.deleteById(locationId);
+		partyRepository.deleteById(partyId);
+		memberRepository.deleteById(memberId);
 		SecurityContextHolder.clearContext();
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -45,6 +45,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 	private long memberId;
 	private long partyId;
 	private long locationId;
+	private long partyMemberId;
 
 	@Autowired
 	MockMvc mockMvc;
@@ -75,7 +76,8 @@ public class RouteControllerTest extends MysqlTestContainer {
 		Location location = locationRepository.save(getLocationData());
 		locationId = location.getId();
 
-		partyMemberRepository.save(getPartyMemberData(member, party));
+		PartyMember partyMember = partyMemberRepository.save(getPartyMemberData(member, party));
+		partyMemberId = partyMember.getId();
 
 		SecurityContext context = SecurityContextHolder.getContext();
 		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Optional;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -65,6 +66,11 @@ public class RouteServiceTest {
 			new UsernamePasswordAuthenticationToken(1L, null, Collections.EMPTY_LIST);
 
 		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@AfterEach
+	void tearDown() {
+		SecurityContextHolder.clearContext();
 	}
 
 	@Nested

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -1,0 +1,189 @@
+package org.prgrms.wumo.domain.route.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.prgrms.wumo.domain.route.dto.request.RouteRegisterRequest;
+import org.prgrms.wumo.domain.route.dto.response.RouteRegisterResponse;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RouteService의 ")
+public class RouteServiceTest {
+
+	private final long routeId = 1L;
+	private final long locationId = 1L;
+	private final long partyId = 1L;
+
+	@InjectMocks
+	RouteService routeService;
+
+	@Mock
+	RouteRepository routeRepository;
+
+	@Mock
+	PartyRepository partyRepository;
+
+	@Mock
+	LocationRepository locationRepository;
+
+	@Mock
+	PartyMemberRepository partyMemberRepository;
+
+	@BeforeEach
+	void setUp() {
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+			new UsernamePasswordAuthenticationToken(1L, null, Collections.EMPTY_LIST);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@Nested
+	@DisplayName("registerRoute 메소드는 루트에 후보지 등록 요청 시 ")
+	class RegisterRoute {
+		//given
+		Party party = getPartyData();
+		Location location = getLocationData();
+		Route route = getRouteData();
+
+		@Test
+		@DisplayName("모임의 루트가 이미 있다면 그 루트에 후보지를 추가한다")
+		void success_not_first_register() {
+			//given
+			RouteRegisterRequest routeRegisterRequest
+				= new RouteRegisterRequest(routeId, locationId, partyId);
+
+			//mocking
+			given(routeRepository.findById(anyLong()))
+				.willReturn(Optional.of(route));
+			given(partyRepository.findById(anyLong()))
+				.willReturn(Optional.of(party));
+			given(locationRepository.findById(anyLong()))
+				.willReturn(Optional.of(location));
+			given(partyMemberRepository.existsByPartyIdAndMemberId(anyLong(), anyLong()))
+				.willReturn(true);
+
+			//when
+			RouteRegisterResponse routeRegisterResponse = routeService.registerRoute(routeRegisterRequest);
+
+			//then
+			assertThat(routeRegisterResponse.id()).isEqualTo(routeId);
+			then(routeRepository)
+				.should()
+				.findById(anyLong());
+		}
+
+		@Test
+		@DisplayName("모임의 루트가 처음 생성되는거라면 루트 생성 후, 후보지를 루트에 추가한다")
+		void success_first_register() {
+			//given
+			RouteRegisterRequest routeRegisterRequest
+				= new RouteRegisterRequest(null, locationId, partyId);
+
+			//mocking
+			given(routeRepository.save(any(Route.class)))
+				.willReturn(route);
+			given(partyRepository.findById(anyLong()))
+				.willReturn(Optional.of(party));
+			given(locationRepository.findById(anyLong()))
+				.willReturn(Optional.of(location));
+			given(partyMemberRepository.existsByPartyIdAndMemberId(anyLong(), anyLong()))
+				.willReturn(true);
+
+			//when
+			RouteRegisterResponse routeRegisterResponse = routeService.registerRoute(routeRegisterRequest);
+
+			//then
+			assertThat(routeRegisterResponse.id()).isEqualTo(routeId);
+			then(routeRepository)
+				.should()
+				.save(any(Route.class));
+		}
+
+		@Test
+		@DisplayName("모임의 회원이 아니라면 예외가 발생한다")
+		void fail_not_party_member() {
+			//given
+			RouteRegisterRequest routeRegisterRequest
+				= new RouteRegisterRequest(routeId, locationId, partyId);
+
+			//mocking
+			given(partyRepository.findById(anyLong()))
+				.willReturn(Optional.of(party));
+			given(locationRepository.findById(anyLong()))
+				.willReturn(Optional.of(location));
+			given(partyMemberRepository.existsByPartyIdAndMemberId(anyLong(), anyLong()))
+				.willReturn(false);
+
+			//when, then
+			assertThatThrownBy(() -> routeService.registerRoute(routeRegisterRequest))
+				.isInstanceOf(AccessDeniedException.class)
+				.hasMessage("잘못된 접근입니다.");
+		}
+	}
+
+	private Party getPartyData() {
+		return Party.builder()
+			.id(partyId)
+			.name("제주도 한달 살기")
+			.coverImage("http://~~~.png")
+			.startDate(LocalDateTime.now())
+			.endDate(LocalDateTime.now().plusDays(1))
+			.build();
+	}
+
+	private Location getLocationData() {
+		return Location.builder()
+			.id(locationId)
+			.name("오예스 찜닭")
+			.latitude(12.3456F)
+			.longitude(34.5678F)
+			.address("제주시 서귀포시 서귀동")
+			.image("http://~~~.png")
+			.visitDate(LocalDateTime.now().plusDays(10))
+			.category(Category.MEAL)
+			.expectedCost(40000)
+			.partyId(partyId)
+			.build();
+	}
+
+	private Route getRouteData() {
+		return Route.builder()
+			.id(routeId)
+			.isPublic(false)
+			.locations(new ArrayList<>() {{
+				add(getLocationData());
+			}})
+			.party(getPartyData())
+			.build();
+	}
+}

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -185,7 +185,6 @@ public class RouteServiceTest {
 	private Route getRouteData() {
 		return Route.builder()
 			.id(routeId)
-			.isPublic(false)
 			.locations(new ArrayList<>() {{
 				add(getLocationData());
 			}})


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->
- 후보지를 루트에 등록하는 기능 구현 및 테스트

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 객체의 연관관계들로 인해 테스트 코드가 많이 깁니다
조금 더 줄일 수 있는 방법이 있을까요?
- 현재 로그인한 사용자가 해당 모임멤버인지 검증 후 
맞다면 루트에 후보지를 등록할 수 있도록 로직을 구현하였습니다
제가 놓친 부분이 없는지, 코드를 조금 더 깔끔하게 짤 수 있을지 등등 
루트 등록 서비스 코드를 꼼꼼하게 매운맛으로 봐주시면 감사하겠습니다!

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-179], [WUMO-180]

[WUMO-179]: https://shoekream.atlassian.net/browse/WUMO-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-180]: https://shoekream.atlassian.net/browse/WUMO-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ