### PR TITLE
[WUMO-181] Party 기능 전역에 로그인 기능 추가 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyController.java
@@ -41,13 +41,12 @@ public class PartyController {
 		return new ResponseEntity<>(partyService.registerParty(partyRegisterRequest), HttpStatus.CREATED);
 	}
 
-	@GetMapping("/members/{memberId}")
+	@GetMapping("/members/me")
 	@Operation(summary = "사용자 기준 모임 목록 조회")
 	public ResponseEntity<PartyGetAllResponse> getAllParty(
-			@PathVariable @Parameter(description = "사용자 식별자", required = true) Long memberId,
 			@Valid PartyGetRequest partyGetRequest
 	) {
-		return ResponseEntity.ok(partyService.getAllParty(memberId, partyGetRequest));
+		return ResponseEntity.ok(partyService.getAllParty(partyGetRequest));
 	}
 
 	@GetMapping("/{partyId}")

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
@@ -38,10 +38,6 @@ public record PartyRegisterRequest(
 		@Schema(description = "입장 비밀번호", example = "1234", required = false)
 		String password,
 
-		@NotNull(message = "모임 생성 사용자 식별자는 필수 입력사항입니다.")
-		@Schema(description = "사용자 식별자", example = "1", required = true)
-		Long memberId,
-
 		@Schema(description = "역할", example = "총무", required = false)
 		String role
 

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepository.java
@@ -1,10 +1,13 @@
 package org.prgrms.wumo.domain.party.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.prgrms.wumo.domain.party.model.PartyMember;
 
 public interface PartyMemberCustomRepository {
+
+	Optional<PartyMember> findByPartyIdAndIsLeader(Long partyId);
 
 	List<PartyMember> findAllByMemberId(Long memberId, Long cursorId, int pageSize);
 

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepositoryImpl.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.party.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.model.QPartyMember;
@@ -18,6 +19,19 @@ public class PartyMemberCustomRepositoryImpl implements PartyMemberCustomReposit
 	private final JPAQueryFactory jpaQueryFactory;
 
 	private final QPartyMember qPartyMember = QPartyMember.partyMember;
+
+	@Override
+	public Optional<PartyMember> findByPartyIdAndIsLeader(Long partyId) {
+		return Optional.ofNullable(
+				jpaQueryFactory
+						.selectFrom(qPartyMember)
+						.where(
+								eqPartyId(partyId),
+								isLeader()
+						)
+						.fetchOne()
+		);
+	}
 
 	@Override
 	public List<PartyMember> findAllByMemberId(Long memberId, Long cursorId, int pageSize) {
@@ -45,6 +59,14 @@ public class PartyMemberCustomRepositoryImpl implements PartyMemberCustomReposit
 
 	private BooleanExpression gtPartyMemberId(Long cursorId) {
 		return (cursorId != null) ? qPartyMember.id.gt(cursorId) : null;
+	}
+
+	private BooleanExpression eqPartyId(Long partyId) {
+		return qPartyMember.party.id.eq(partyId);
+	}
+
+	private BooleanExpression isLeader() {
+		return qPartyMember.isLeader.eq(true);
 	}
 
 	private BooleanExpression eqMemberId(Long memberId) {

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -83,8 +83,9 @@ class PartyControllerTest extends MysqlTestContainer {
 	void clean() {
 		partyMemberRepository.deleteAll();
 		partyRepository.deleteAll();
-		memberRepository.deleteAll();
+		memberRepository.deleteById(member.getId());
 		member = null;
+		SecurityContextHolder.clearContext();
 	}
 
 	@Test

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -21,6 +21,8 @@ import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
 import org.prgrms.wumo.domain.party.dto.request.PartyUpdateRequest;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
 import org.prgrms.wumo.domain.party.service.PartyService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -53,6 +55,12 @@ class PartyControllerTest extends MysqlTestContainer {
 	@Autowired
 	private MemberRepository memberRepository;
 
+	@Autowired
+	private PartyRepository partyRepository;
+
+	@Autowired
+	private PartyMemberRepository partyMemberRepository;
+
 	private Member member;
 
 	@BeforeEach
@@ -73,6 +81,8 @@ class PartyControllerTest extends MysqlTestContainer {
 
 	@AfterEach
 	void clean() {
+		partyMemberRepository.deleteAll();
+		partyRepository.deleteAll();
 		memberRepository.deleteAll();
 		member = null;
 	}

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
+import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -60,6 +64,11 @@ class PartyControllerTest extends MysqlTestContainer {
 						.nickname("테드창")
 						.build()
 		);
+
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(member.getId(), null, Collections.emptyList());
+		context.setAuthentication(usernamePasswordAuthenticationToken);
 	}
 
 	@AfterEach
@@ -94,7 +103,7 @@ class PartyControllerTest extends MysqlTestContainer {
 		PartyRegisterResponse partyRegisterResponse = partyService.registerParty(partyRegisterRequest);
 
 		//when
-		ResultActions resultActions = mockMvc.perform(get("/api/v1/party/members/{memberId}", partyRegisterRequest.memberId())
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/party/members/me")
 				.param("cursorId", (String)null)
 				.param("pageSize", "5"));
 
@@ -188,7 +197,6 @@ class PartyControllerTest extends MysqlTestContainer {
 				"팀 설립 기념 워크샵",
 				"https://~.jpeg",
 				"1234",
-				member.getId(),
 				"총무"
 		);
 	}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- Party(모임) 서비스 코드 전역에 등록, 조회, 수정, 삭제에 JwtUtil를 활용한 Access 제어 추가

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 특이사항 없음

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-182], [WUMO-183]

[WUMO-182]: https://shoekream.atlassian.net/browse/WUMO-182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-183]: https://shoekream.atlassian.net/browse/WUMO-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ