### PR TITLE
[WUMO-40] PartyMember 삭제 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyMemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyMemberController.java
@@ -60,13 +60,23 @@ public class PartyMemberController {
 		return ResponseEntity.ok(partyMemberService.updatePartyMember(partyId, partyMemberUpdateRequest));
 	}
 
-	@DeleteMapping("/{partyId}/members/{memberId}")
-	@Operation(summary = "모임 구성원 삭제(추방)")
+	@DeleteMapping("/{partyId}/members")
+	@Operation(summary = "모임 구성원 삭제 (모임 탈퇴)")
 	public ResponseEntity<Void> deletePartyMember(
-			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId,
-			@PathVariable @Parameter(description = "사용자 식별자", required = true) Long memberId
+			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId
 	) {
-		return ResponseEntity.ok(null);
+		partyMemberService.deletePartyMember(partyId);
+		return ResponseEntity.ok().build();
+	}
+
+	@DeleteMapping("/{partyId}/members/{memberId}")
+	@Operation(summary = "모임 구성원 삭제 (모임 추방)")
+	public ResponseEntity<Long> deletePartyMember(
+			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId,
+			@PathVariable @Parameter(description = "추방할 사용자 식별자", required = true) Long memberId
+	) {
+		partyMemberService.deletePartyMember(partyId, memberId);
+		return ResponseEntity.ok(memberId);
 	}
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
@@ -1,6 +1,6 @@
 package org.prgrms.wumo.domain.party.dto.request;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
@@ -19,11 +19,11 @@ public record PartyRegisterRequest(
 
 		@NotNull(message = "시작일은 필수 입력사항입니다.")
 		@Schema(description = "시작일", example = "2023-02-21", required = true)
-		LocalDateTime startDate,
+		LocalDate startDate,
 
 		@NotNull(message = "종료일은 필수 입력사항입니다.")
 		@Schema(description = "종료일", example = "2023-02-22", required = true)
-		LocalDateTime endDate,
+		LocalDate endDate,
 
 		@NotBlank(message = "모임 설명은 필수 입력사항입니다.")
 		@Length(max = 255, message = "모임 설명은 {max}자를 초과할 수 없습니다.")

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyUpdateRequest.java
@@ -1,6 +1,6 @@
 package org.prgrms.wumo.domain.party.dto.request;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import org.hibernate.validator.constraints.Length;
 
@@ -14,10 +14,10 @@ public record PartyUpdateRequest(
 		String name,
 
 		@Schema(description = "시작일", example = "2023-02-21", required = false)
-		LocalDateTime startDate,
+		LocalDate startDate,
 
 		@Schema(description = "종료일", example = "2023-02-22", required = false)
-		LocalDateTime endDate,
+		LocalDate endDate,
 
 		@Length(max = 255, message = "모임 설명은 {max}자를 초과할 수 없습니다.")
 		@Schema(description = "종료일", example = "팀 설립 기념 워크샵", required = false)

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetResponse.java
@@ -1,6 +1,6 @@
 package org.prgrms.wumo.domain.party.dto.response;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -14,10 +14,10 @@ public record PartyGetResponse(
 		String name,
 
 		@Schema(description = "시작일", example = "2023-02-21", required = true)
-		LocalDateTime startDate,
+		LocalDate startDate,
 
 		@Schema(description = "종료일", example = "2023-02-22", required = true)
-		LocalDateTime endDate,
+		LocalDate endDate,
 
 		@Schema(description = "종료일", example = "팀 설립 기념 워크샵", required = true)
 		String description,

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
@@ -21,6 +21,7 @@ import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.party.repository.PartyRepository;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
+import org.prgrms.wumo.global.exception.custom.PartyNotEmptyException;
 import org.prgrms.wumo.global.jwt.JwtUtil;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -60,6 +61,8 @@ public class PartyMemberService {
 
 	@Transactional(readOnly = true)
 	public PartyMemberGetAllResponse getAllPartyMembers(Long partyId, PartyMemberGetRequest partyMemberGetRequest) {
+		getPartyMemberEntity(partyId, JwtUtil.getMemberId());
+
 		List<PartyMember> partyMembers =
 				partyMemberRepository.findAllByPartyId(partyId, partyMemberGetRequest.cursorId(), partyMemberGetRequest.pageSize());
 
@@ -88,7 +91,7 @@ public class PartyMemberService {
 				partyRepository.deleteById(partyId);
 				return;
 			} else {
-				throw new IllegalStateException("본인을 제외하고 모임에 가입된 회원이 없어야 합니다.");
+				throw new PartyNotEmptyException("본인을 제외하고 모임에 가입된 회원이 없어야 합니다.");
 			}
 		}
 

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -5,6 +5,8 @@ import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetAllResponse;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetDetailResponse;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyRegisterResponse;
 
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import javax.persistence.EntityNotFoundException;
@@ -83,8 +85,8 @@ public class PartyService {
 		Party party = partyLeader.getParty();
 		party.update(
 				partyUpdateRequest.name(),
-				partyUpdateRequest.startDate(),
-				partyUpdateRequest.endDate(),
+				LocalDateTime.of(partyUpdateRequest.startDate(), LocalTime.MIN),
+				LocalDateTime.of(partyUpdateRequest.endDate(), LocalTime.MAX),
 				partyUpdateRequest.description(),
 				partyUpdateRequest.coverImage(),
 				partyUpdateRequest.password()

--- a/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import javax.persistence.EntityNotFoundException;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
 import org.prgrms.wumo.global.exception.custom.ImageDeleteFailedException;
 import org.prgrms.wumo.global.exception.custom.ImageUploadFailedException;
+import org.prgrms.wumo.global.exception.custom.PartyNotEmptyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -37,7 +38,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler({
 		ImageUploadFailedException.class, IllegalArgumentException.class, ImageDeleteFailedException.class,
-			EntityNotFoundException.class, IllegalStateException.class
+			EntityNotFoundException.class, PartyNotEmptyException.class
 	})
 	public ResponseEntity<ExceptionResponse> handleException(RuntimeException runtimeException) {
 		log.info("exception : " + runtimeException);

--- a/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
@@ -37,7 +37,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler({
 		ImageUploadFailedException.class, IllegalArgumentException.class, ImageDeleteFailedException.class,
-			EntityNotFoundException.class
+			EntityNotFoundException.class, IllegalStateException.class
 	})
 	public ResponseEntity<ExceptionResponse> handleException(RuntimeException runtimeException) {
 		log.info("exception : " + runtimeException);

--- a/src/main/java/org/prgrms/wumo/global/exception/custom/PartyNotEmptyException.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/custom/PartyNotEmptyException.java
@@ -1,0 +1,9 @@
+package org.prgrms.wumo.global.exception.custom;
+
+public class PartyNotEmptyException extends RuntimeException {
+
+	public PartyNotEmptyException(String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
@@ -1,5 +1,8 @@
 package org.prgrms.wumo.global.mapper;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import org.prgrms.wumo.domain.member.model.Member;
@@ -21,8 +24,8 @@ public class PartyMapper {
 	public static Party toParty(PartyRegisterRequest partyRegisterRequest) {
 		return Party.builder()
 				.name(partyRegisterRequest.name())
-				.startDate(partyRegisterRequest.startDate())
-				.endDate(partyRegisterRequest.endDate())
+				.startDate(LocalDateTime.of(partyRegisterRequest.startDate(), LocalTime.MIN))
+				.endDate(LocalDateTime.of(partyRegisterRequest.endDate(), LocalTime.MIN))
 				.description(partyRegisterRequest.description())
 				.coverImage(partyRegisterRequest.coverImage())
 				.password(partyRegisterRequest.password())
@@ -38,8 +41,8 @@ public class PartyMapper {
 				.map(party -> new PartyGetResponse(
 						party.getId(),
 						party.getName(),
-						party.getStartDate(),
-						party.getEndDate(),
+						LocalDate.from(party.getStartDate()),
+						LocalDate.from(party.getEndDate()),
 						party.getDescription(),
 						party.getCoverImage()))
 				.toList();
@@ -50,8 +53,8 @@ public class PartyMapper {
 		return new PartyGetResponse(
 				party.getId(),
 				party.getName(),
-				party.getStartDate(),
-				party.getEndDate(),
+				LocalDate.from(party.getStartDate()),
+				LocalDate.from(party.getEndDate()),
 				party.getDescription(),
 				party.getCoverImage()
 		);

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -8,7 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Collections;
 
 import org.junit.jupiter.api.AfterEach;
@@ -150,8 +150,8 @@ class PartyControllerTest extends MysqlTestContainer {
 		PartyRegisterResponse partyRegisterResponse = partyService.registerParty(partyRegisterRequest);
 		PartyUpdateRequest partyUpdateRequest = new PartyUpdateRequest(
 				"오예스 워크샵 (수정)",
-				LocalDateTime.now().plusDays(1),
-				LocalDateTime.now().plusDays(2),
+				LocalDate.now().plusDays(1),
+				LocalDate.now().plusDays(2),
 				"팀 설립 기념 워크샵 (수정)",
 				"https://~~~.jpeg",
 				"4321"
@@ -193,8 +193,8 @@ class PartyControllerTest extends MysqlTestContainer {
 	private PartyRegisterRequest getPartyRegisterRequest() {
 		return new PartyRegisterRequest(
 				"오예스 워크샵",
-				LocalDateTime.now(),
-				LocalDateTime.now().plusDays(1),
+				LocalDate.now(),
+				LocalDate.now().plusDays(1),
 				"팀 설립 기념 워크샵",
 				"https://~.jpeg",
 				"1234",

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
@@ -137,6 +137,9 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 	@Test
 	@DisplayName("특정 모임의 구성원을 조회할 수 있다.")
 	void getAllPartyMembers() throws Exception {
+		//given
+		setAuthentication(leader.getId());
+
 		//when
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/parties/{partyId}/members", party.getId())
 						.param("cursorId", (String)null)

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
@@ -108,7 +108,10 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 
 	@AfterEach
 	void clean() {
-		partyMemberRepository.deleteById(partyParticipant.getId());
+		if (partyParticipant != null) {
+			partyMemberRepository.deleteById(partyParticipant.getId());
+		}
+		partyParticipant = null;
 		partyMemberRepository.deleteById(partyLeader.getId());
 		partyRepository.deleteById(party.getId());
 		memberRepository.deleteById(leader.getId());

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.party.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -65,6 +66,8 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 
 	private PartyMember partyLeader;
 
+	private PartyMember partyParticipant;
+
 	@BeforeEach
 	void setup() {
 		leader = memberRepository.save(
@@ -105,6 +108,7 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 
 	@AfterEach
 	void clean() {
+		partyMemberRepository.deleteById(partyParticipant.getId());
 		partyMemberRepository.deleteById(partyLeader.getId());
 		partyRepository.deleteById(party.getId());
 		memberRepository.deleteById(leader.getId());
@@ -171,6 +175,49 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.nickname").value(leader.getNickname()))
 				.andExpect(jsonPath("$.role").value(getPartyMemberUpdateRequest().role()))
 				.andExpect(jsonPath("$.profileImage").value(leader.getProfileImage()))
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("모임 생성자는 구성원을 추방할 수 있다.")
+	void deletePartyMemberWithLeader() throws Exception {
+		//given
+		partyParticipant = partyMemberRepository.save(
+				PartyMember.builder()
+						.member(participant)
+						.party(party)
+						.role("요리사")
+						.build()
+		);
+		setAuthentication(leader.getId());
+
+		//when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/parties/{partyId}/members/{memberId}", party.getId(), participant.getId()));
+
+		//then
+		resultActions
+				.andExpect(status().isOk())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("모임에서 탈퇴할 수 있다.")
+	void deletePartyMember() throws Exception {
+		//given
+		partyParticipant = partyMemberRepository.save(
+				PartyMember.builder()
+						.member(participant)
+						.party(party)
+						.role("요리사")
+						.build()
+		);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/parties/{partyId}/members", party.getId()));
+
+		//then
+		resultActions
+				.andExpect(status().isOk())
 				.andDo(print());
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
@@ -108,10 +108,6 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 
 	@AfterEach
 	void clean() {
-		if (partyParticipant != null) {
-			partyMemberRepository.deleteById(partyParticipant.getId());
-		}
-		partyParticipant = null;
 		partyMemberRepository.deleteById(partyLeader.getId());
 		partyRepository.deleteById(party.getId());
 		memberRepository.deleteById(leader.getId());

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyMemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyMemberServiceTest.java
@@ -33,6 +33,7 @@ import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.party.repository.PartyRepository;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -100,10 +101,7 @@ class PartyMemberServiceTest {
 				.build();
 		partyMemberRegisterRequest = new PartyMemberRegisterRequest("운전기사");
 
-		SecurityContext context = SecurityContextHolder.getContext();
-		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-				new UsernamePasswordAuthenticationToken(participant.getId(), null, Collections.emptyList());
-		context.setAuthentication(usernamePasswordAuthenticationToken);
+		setAuthentication(participant.getId());
 	}
 
 	@Nested
@@ -232,6 +230,153 @@ class PartyMemberServiceTest {
 					.findByPartyIdAndMemberId(party.getId(), participant.getId());
 		}
 
+	}
+
+	@Nested
+	@DisplayName("deletePartyMember 메소드는 호출시")
+	class DeletePartyMember {
+
+		@Test
+		@DisplayName("모임을 생성한 회원이 아니라면 구성원에서 삭제한다.")
+		void successWithNotLeader() {
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), participant.getId()))
+					.willReturn(Optional.of(partyParticipant));
+
+			//when
+			partyMemberService.deletePartyMember(party.getId());
+
+			//then
+			then(partyMemberRepository)
+					.should()
+					.findByPartyIdAndMemberId(party.getId(), participant.getId());
+			then(partyMemberRepository)
+					.should()
+					.delete(any(PartyMember.class));
+		}
+
+		@Test
+		@DisplayName("모임을 생성한 회원이고 자신을 제외한 구성원이 없다면 구성원과 모임을 삭제한다.")
+		void successWithParticipant() {
+			//given
+			setAuthentication(leader.getId());
+
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), leader.getId()))
+					.willReturn(Optional.of(partyLeader));
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 2))
+					.willReturn(List.of(partyLeader));
+
+			//when
+			partyMemberService.deletePartyMember(party.getId());
+
+			//then
+			then(partyMemberRepository)
+					.should()
+					.findByPartyIdAndMemberId(party.getId(), leader.getId());
+			then(partyMemberRepository)
+					.should()
+					.delete(partyLeader);
+			then(partyRepository)
+					.should()
+					.deleteById(party.getId());
+		}
+
+		@Test
+		@DisplayName("모임을 생성한 회원이고 자신을 제외한 구성원이 있다면 예외가 발생한다.")
+		void failed() {
+			//given
+			setAuthentication(leader.getId());
+
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), leader.getId()))
+					.willReturn(Optional.of(partyLeader));
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 2))
+					.willReturn(List.of(partyLeader, partyParticipant));
+
+			//when
+			//then
+			Assertions.assertThrows(IllegalStateException.class,
+					() -> partyMemberService.deletePartyMember(party.getId()));
+		}
+
+		@Test
+		@DisplayName("모임을 생성한 회원이면 다른 구성원을 추방할 수 있다.")
+		void successKickWithLeader() {
+			//given
+			setAuthentication(leader.getId());
+
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), leader.getId()))
+					.willReturn(Optional.of(partyLeader));
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), participant.getId()))
+					.willReturn(Optional.of(partyParticipant));
+
+			//when
+			partyMemberService.deletePartyMember(party.getId(), participant.getId());
+
+				//then
+			then(partyMemberRepository)
+					.should()
+					.findByPartyIdAndMemberId(party.getId(), leader.getId());
+			then(partyMemberRepository)
+					.should()
+					.findByPartyIdAndMemberId(party.getId(), participant.getId());
+			then(partyMemberRepository)
+					.should()
+					.delete(any(PartyMember.class));
+		}
+
+		@Test
+		@DisplayName("모임을 생성한 회원이고 구성원이 자신뿐이면 자신을 추방할 수 있다.")
+		void successSelfKickWithLeader() {
+			//given
+			setAuthentication(leader.getId());
+
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), leader.getId()))
+					.willReturn(Optional.of(partyLeader));
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 2))
+					.willReturn(List.of(partyLeader));
+
+			//when
+			partyMemberService.deletePartyMember(party.getId(), leader.getId());
+
+			//then
+			then(partyMemberRepository)
+					.should()
+					.findByPartyIdAndMemberId(party.getId(), leader.getId());
+			then(partyMemberRepository)
+					.should()
+					.findAllByPartyId(party.getId(), null, 2);
+			then(partyMemberRepository)
+					.should()
+					.delete(any(PartyMember.class));
+			then(partyRepository)
+					.should()
+					.deleteById(party.getId());
+		}
+
+		@Test
+		@DisplayName("모임을 생성한 회원이 아니면 다른 구성원을 추방시 예외가 발생한다.")
+		void failedKickWithParticipant() {
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), participant.getId()))
+					.willReturn(Optional.of(partyParticipant));
+
+			//when
+			//then
+			Assertions.assertThrows(AccessDeniedException.class,
+					() -> partyMemberService.deletePartyMember(party.getId(), leader.getId()));
+		}
+
+	}
+
+	private void setAuthentication(Long memberId) {
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+		context.setAuthentication(usernamePasswordAuthenticationToken);
 	}
 
 }

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -6,7 +6,9 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -71,8 +73,8 @@ class PartyServiceTest {
 
 		partyRegisterRequest = new PartyRegisterRequest(
 				"오예스 워크샵",
-				LocalDateTime.now(),
-				LocalDateTime.now().plusDays(1),
+				LocalDate.now(),
+				LocalDate.now().plusDays(1),
 				"팀 설립 기념 워크샵",
 				"https://~.jpeg",
 				"1234",
@@ -82,8 +84,8 @@ class PartyServiceTest {
 		party = Party.builder()
 				.id(1L)
 				.name(partyRegisterRequest.name())
-				.startDate(partyRegisterRequest.startDate())
-				.endDate(partyRegisterRequest.endDate())
+				.startDate(LocalDateTime.of(partyRegisterRequest.startDate(), LocalTime.MIN))
+				.endDate(LocalDateTime.of(partyRegisterRequest.endDate(), LocalTime.MAX))
 				.description(partyRegisterRequest.description())
 				.coverImage(partyRegisterRequest.coverImage())
 				.password(partyRegisterRequest.password())
@@ -215,8 +217,8 @@ class PartyServiceTest {
 			//then
 			assertThat(myParty.id()).isEqualTo(party.getId());
 			assertThat(myParty.name()).isEqualTo(party.getName());
-			assertThat(myParty.startDate()).isEqualTo(party.getStartDate());
-			assertThat(myParty.endDate()).isEqualTo(party.getEndDate());
+			assertThat(myParty.startDate()).isEqualTo(LocalDate.from(party.getStartDate()));
+			assertThat(myParty.endDate()).isEqualTo(LocalDate.from(party.getEndDate()));
 			assertThat(myParty.description()).isEqualTo(party.getDescription());
 			assertThat(myParty.coverImage()).isEqualTo(party.getCoverImage());
 
@@ -244,8 +246,8 @@ class PartyServiceTest {
 	class UpdateParty {
 		PartyUpdateRequest partyUpdateRequest = new PartyUpdateRequest(
 				"오예스 워크샵 (수정)",
-				LocalDateTime.now(),
-				LocalDateTime.now().plusDays(2),
+				LocalDate.now(),
+				LocalDate.now().plusDays(2),
 				"팀 설립 기념 워크샵 (수정)",
 				null,
 				"4321"
@@ -285,8 +287,8 @@ class PartyServiceTest {
 			//given
 			PartyUpdateRequest wrongRequest = new PartyUpdateRequest(
 					null,
-					LocalDateTime.now().plusDays(1),
-					LocalDateTime.now(),
+					LocalDate.now().plusDays(1),
+					LocalDate.now(),
 					null,
 					null,
 					null


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 모임 구성원(PartyMember) 삭제(탈퇴, 추방) 기능 구현 및 테스트

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 엔드포인트와 메서드를 분리했지만 파티장이 자신을 추방하는 경우도 가능하게 구현했습니다.
  - deletePartyMember(Party, Member) 에서 대상이 되는 Member가 자신인 경우
  - deletePartyMember(Party)인 탈퇴 처리 로직을 호출합니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-198], [WUMO-199]

[WUMO-198]: https://shoekream.atlassian.net/browse/WUMO-198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-199]: https://shoekream.atlassian.net/browse/WUMO-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ