### PR TITLE
[WUMO-53] Route에서 Location 삭제 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/location/api/LocationController.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/api/LocationController.java
@@ -1,10 +1,7 @@
 package org.prgrms.wumo.domain.location.api;
 
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
-import lombok.RequiredArgsConstructor;
+
 import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationSpendingUpdateRequest;
@@ -23,7 +20,13 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/v1/locations")
@@ -35,7 +38,7 @@ public class LocationController {
 	@PostMapping
 	@Operation(summary = "후보장소 등록")
 	public ResponseEntity<LocationRegisterResponse> registerLocation(
-			@RequestBody @Valid LocationRegisterRequest locationRegisterRequest) {
+		@RequestBody @Valid LocationRegisterRequest locationRegisterRequest) {
 
 		return new ResponseEntity<>(locationService.registerLocation(locationRegisterRequest), HttpStatus.CREATED);
 	}
@@ -43,7 +46,7 @@ public class LocationController {
 	@GetMapping("/{locationId}")
 	@Operation(summary = "후보장소 상세 조회")
 	public ResponseEntity<LocationGetResponse> getLocation(
-			@PathVariable @Parameter(description = "조회할 후보장소 아이디") Long locationId) {
+		@PathVariable @Parameter(description = "조회할 후보장소 아이디") Long locationId) {
 
 		return ResponseEntity.ok(locationService.getLocation(locationId));
 	}
@@ -51,14 +54,14 @@ public class LocationController {
 	@GetMapping
 	@Operation(summary = "후보장소 목록 조회")
 	public ResponseEntity<LocationGetAllResponse> getAllLocation(
-			@Valid LocationGetAllRequest locationGetAllRequest) {
+		@Valid LocationGetAllRequest locationGetAllRequest) {
 		return ResponseEntity.ok(locationService.getAllLocations(locationGetAllRequest));
 	}
 
 	@PatchMapping("/spending")
 	@Operation(summary = "후보장소 사용 금액 갱신")
 	public ResponseEntity<LocationSpendingUpdateResponse> updateSpending(
-			@RequestBody @Valid LocationSpendingUpdateRequest locationSpendingUpdateRequest
+		@RequestBody @Valid LocationSpendingUpdateRequest locationSpendingUpdateRequest
 	) {
 		return ResponseEntity.ok(null);
 	}
@@ -66,7 +69,7 @@ public class LocationController {
 	@PatchMapping
 	@Operation(summary = "후보장소 수정")
 	public ResponseEntity<Void> updateLocation(
-			@RequestBody @Valid LocationUpdateRequest locationUpdateRequest) {
+		@RequestBody @Valid LocationUpdateRequest locationUpdateRequest) {
 
 		return ResponseEntity.ok().build();
 	}
@@ -74,8 +77,18 @@ public class LocationController {
 	@DeleteMapping("/{locationId}")
 	@Operation(summary = "후보장소 삭제")
 	public ResponseEntity<Void> deleteLocation(
-			@PathVariable @Parameter(description = "삭제할 후보장소 아이디") Long locationId) {
+		@PathVariable @Parameter(description = "삭제할 후보장소 아이디") Long locationId) {
 
 		return ResponseEntity.ok().build();
 	}
+
+	@DeleteMapping
+	@Operation(summary = "루트에서 후보지 삭제")
+	public ResponseEntity<Void> deleteRouteLocation(
+		@RequestParam @Parameter(description = "루트에서 삭제할 후보지 식별자") long locationId) {
+
+		locationService.deleteRouteLocation(locationId);
+		return ResponseEntity.ok().build();
+	}
+
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.location.model;
 
 import java.time.LocalDateTime;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -12,12 +13,14 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
+
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.global.audit.BaseTimeEntity;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.prgrms.wumo.domain.route.model.Route;
-import org.prgrms.wumo.global.audit.BaseTimeEntity;
 
 @Getter
 @Entity
@@ -61,7 +64,7 @@ public class Location extends BaseTimeEntity {
 	private Category category;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "route_id", updatable = false, unique = false)
+	@JoinColumn(name = "route_id", updatable = true, unique = false)
 	private Route route;
 
 	@Column(name = "party_id", updatable = false, unique = false)
@@ -69,8 +72,8 @@ public class Location extends BaseTimeEntity {
 
 	@Builder
 	public Location(Long id, String name, String address, Float latitude, Float longitude, String image,
-			String description,
-			LocalDateTime visitDate, int expectedCost, int spending, Category category, Route route, Long partyId) {
+		String description,
+		LocalDateTime visitDate, int expectedCost, int spending, Category category, Route route, Long partyId) {
 		this.id = id;
 		this.name = name;
 		this.address = address;
@@ -89,6 +92,10 @@ public class Location extends BaseTimeEntity {
 	// TODO 추후 Party 이용, Route 지정할 계획
 	public void addRoute(Route route) {
 		this.route = route;
+	}
+
+	public void deleteRoute() {
+		this.route = null;
 	}
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -4,9 +4,11 @@ import static org.prgrms.wumo.global.mapper.LocationMapper.toLocation;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetAllResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationRegisterResponse;
+
 import java.util.List;
+
 import javax.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
+
 import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
@@ -17,9 +19,12 @@ import org.prgrms.wumo.domain.location.repository.LocationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import lombok.RequiredArgsConstructor;
+
 @Service
 @RequiredArgsConstructor
 public class LocationService {
+
 	private final LocationRepository locationRepository;
 
 	@Transactional
@@ -35,12 +40,21 @@ public class LocationService {
 	// TODO queryDSL 이용, 커서 기반 페이지네이션으로 변경
 	@Transactional(readOnly = true)
 	public LocationGetAllResponse getAllLocations(LocationGetAllRequest locationGetAllRequest) {
-		List<Location> locations = locationRepository.findAllByPartyIdAndCursorIdLimitPageSize(locationGetAllRequest.partyId(),
-				locationGetAllRequest.cursorId(), locationGetAllRequest.pageSize());
+		List<Location> locations = locationRepository.findAllByPartyIdAndCursorIdLimitPageSize(
+			locationGetAllRequest.partyId(),
+			locationGetAllRequest.cursorId(), locationGetAllRequest.pageSize());
 		return toLocationGetAllResponse(locations, locationGetAllRequest.cursorId() + locationGetAllRequest.pageSize());
 	}
 
+	@Transactional
+	public void deleteRouteLocation(long locationId) {
+		Location location = getLocationEntity(locationId);
+		//TODO 요청한 회원이 후보지가 속한 모임멤버인지 확인하기
+		location.deleteRoute();
+	}
+
 	private Location getLocationEntity(Long locationId) {
-		return locationRepository.findById(locationId).orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보 장소입니다"));
+		return locationRepository.findById(locationId)
+			.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보 장소입니다"));
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
@@ -88,9 +88,9 @@ public class MemberController {
 
 	@PatchMapping
 	@Operation(summary = "내 정보 수정")
-	public ResponseEntity<Void> updateMember(
+	public ResponseEntity<MemberGetResponse> updateMember(
 		@RequestBody @Valid MemberUpdateRequest memberUpdateRequest) {
 
-		return ResponseEntity.ok().build();
+		return ResponseEntity.ok(memberService.updateMember(memberUpdateRequest));
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/member/model/Member.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/model/Member.java
@@ -57,6 +57,12 @@ public class Member extends BaseTimeEntity {
 		this.refreshToken = refreshToken;
 	}
 
+	public void update(String nickname, String password, String profileImage) {
+		this.nickname = nickname;
+		this.password = new Password(password);
+		this.profileImage = profileImage;
+	}
+
 	public void logout() {
 		this.refreshToken = "";
 	}

--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -11,6 +11,7 @@ import javax.persistence.EntityNotFoundException;
 
 import org.prgrms.wumo.domain.member.dto.request.MemberLoginRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberRegisterRequest;
+import org.prgrms.wumo.domain.member.dto.request.MemberUpdateRequest;
 import org.prgrms.wumo.domain.member.dto.response.MemberGetResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberLoginResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberRegisterResponse;
@@ -82,6 +83,19 @@ public class MemberService {
 	public MemberGetResponse getMember(long memberId) {
 		validateAccess(memberId);
 		return toMemberGetResponse(getMemberEntity(memberId));
+	}
+
+	@Transactional
+	public MemberGetResponse updateMember(MemberUpdateRequest memberUpdateRequest) {
+		long memberId = memberUpdateRequest.id();
+		validateAccess(memberId);
+
+		Member member = getMemberEntity(memberId);
+		member.update(
+			memberUpdateRequest.nickname(),
+			memberUpdateRequest.password(),
+			memberUpdateRequest.profileImage());
+		return toMemberGetResponse(memberRepository.save(member));
 	}
 
 	private Member getMemberEntity(long memberId) {

--- a/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
@@ -11,7 +11,6 @@ import org.prgrms.wumo.domain.route.dto.response.RouteRegisterResponse;
 import org.prgrms.wumo.domain.route.service.RouteService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -57,14 +56,6 @@ public class RouteController {
 		@Valid RouteGetAllRequest routeGetAllRequest) {
 
 		return ResponseEntity.ok(routeService.getAllRoute(routeGetAllRequest));
-	}
-
-	@DeleteMapping
-	@Operation(summary = "루트에서 후보지 삭제")
-	public ResponseEntity<Void> deleteRouteLocation(
-		@RequestParam @Parameter(description = "루트에서 삭제할 후보장소 아이디") long locationId) {
-
-		return ResponseEntity.ok().build();
 	}
 
 	@PatchMapping

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -49,6 +49,7 @@ public class RouteService {
 
 		if (routeRegisterRequest.routeId() == null) {
 			Route route = routeRepository.save(toRoute(location, party));
+			route.updateLocation(location);
 			return toRouteRegisterResponse(route.getId());
 		}
 

--- a/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
@@ -1,12 +1,14 @@
 package org.prgrms.wumo.domain.location.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +25,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -43,7 +47,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 	LocationTestUtils locationTestUtils = new LocationTestUtils();
 
 	@AfterEach
-	void afterEach(){
+	void afterEach() {
 		locationRepository.deleteAll();
 	}
 
@@ -52,35 +56,35 @@ public class LocationControllerTest extends MysqlTestContainer {
 	void registerLocationTest() throws Exception {
 		// Given
 		LocationRegisterRequest locationRegisterRequest
-				= new LocationRegisterRequest(
-				"프로그래머스 강남 교육장",
-				"강남역 2번출구",
-				locationTestUtils.getLatitude1(),
-				locationTestUtils.getLongitude1(),
-				"http://programmers_gangnam_image.com",
-				Category.STUDY,
-				"이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....",
-				locationTestUtils.getDayToVisit()
-				, 4000,
-				1L
+			= new LocationRegisterRequest(
+			"프로그래머스 강남 교육장",
+			"강남역 2번출구",
+			locationTestUtils.getLatitude1(),
+			locationTestUtils.getLongitude1(),
+			"http://programmers_gangnam_image.com",
+			Category.STUDY,
+			"이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....",
+			locationTestUtils.getDayToVisit()
+			, 4000,
+			1L
 		);
 
 		// When
 		ResultActions resultActions =
-				mockMvc.perform(
-						post("/api/v1/locations")
-								.contentType(MediaType.APPLICATION_JSON_VALUE)
-								.characterEncoding("UTF-8")
-								.content(
-										objectMapper.writeValueAsString(locationRegisterRequest)
-								)
-				);
+			mockMvc.perform(
+				post("/api/v1/locations")
+					.contentType(MediaType.APPLICATION_JSON_VALUE)
+					.characterEncoding("UTF-8")
+					.content(
+						objectMapper.writeValueAsString(locationRegisterRequest)
+					)
+			);
 
 		// Then
 		resultActions
-				.andExpect(status().isCreated())
-				.andExpect(jsonPath("$.id").isNotEmpty())
-				.andDo(print());
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.id").isNotEmpty())
+			.andDo(print());
 
 	}
 
@@ -91,16 +95,16 @@ public class LocationControllerTest extends MysqlTestContainer {
 		Long locationId = locationRepository.save(locationTestUtils.getLocation()).getId();
 
 		// When
-		ResultActions resultActions = mockMvc.perform(get("/api/v1/locations/{locationId}",locationId));
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/locations/{locationId}", locationId));
 
 		// Then
 		resultActions
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.id").isNotEmpty())
-				.andExpect(jsonPath("$.name").value("프로그래머스 강남 교육장"))
-				.andExpect(jsonPath("$.latitude").value(locationTestUtils.getLatitude1()))
-				.andExpect(jsonPath("$.longitude").value(locationTestUtils.getLongitude1()))
-				.andDo(print());
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").isNotEmpty())
+			.andExpect(jsonPath("$.name").value("프로그래머스 강남 교육장"))
+			.andExpect(jsonPath("$.latitude").value(locationTestUtils.getLatitude1()))
+			.andExpect(jsonPath("$.longitude").value(locationTestUtils.getLongitude1()))
+			.andDo(print());
 	}
 
 	@Test
@@ -113,22 +117,40 @@ public class LocationControllerTest extends MysqlTestContainer {
 
 		// When
 		ResultActions resultActions = mockMvc.perform(
-				get("/api/v1/locations")
-						.param("cursorId", "0" )
-						.param("pageSize", "5")
-						.param("partyId", "1")
+			get("/api/v1/locations")
+				.param("cursorId", "0")
+				.param("pageSize", "5")
+				.param("partyId", "1")
 		);
 
 		// Then
 		resultActions
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.locations").isArray())
-				.andExpect(jsonPath("$.locations").isNotEmpty())
-				.andExpect(jsonPath("$.locations[0].id").isNotEmpty())
-				.andExpect(jsonPath("$.locations[0].latitude").value(firstLocation.getLatitude()))
-				.andExpect(jsonPath("$.locations[0].longitude").value(firstLocation.getLongitude()))
-				.andExpect(jsonPath("$.locations[0].spending").value(firstLocation.getSpending()))
-				.andExpect(jsonPath("$.locations[0].expectedCost").value(firstLocation.getExpectedCost()))
-				.andDo(print());
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.locations").isArray())
+			.andExpect(jsonPath("$.locations").isNotEmpty())
+			.andExpect(jsonPath("$.locations[0].id").isNotEmpty())
+			.andExpect(jsonPath("$.locations[0].latitude").value(firstLocation.getLatitude()))
+			.andExpect(jsonPath("$.locations[0].longitude").value(firstLocation.getLongitude()))
+			.andExpect(jsonPath("$.locations[0].spending").value(firstLocation.getSpending()))
+			.andExpect(jsonPath("$.locations[0].expectedCost").value(firstLocation.getExpectedCost()))
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName(" 루트에서 후보지를 삭제한다")
+	void deleteRouteLocationTest() throws Exception {
+		// Given
+		Long locationId = locationRepository.save(locationTestUtils.getLocation()).getId();
+
+		// When
+		ResultActions resultActions = mockMvc.perform(
+			delete("/api/v1/locations")
+				.param("locationId", String.valueOf(locationId))
+		);
+
+		// Then
+		resultActions
+			.andExpect(status().isOk())
+			.andDo(print());
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
@@ -4,11 +4,15 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
 import javax.persistence.EntityNotFoundException;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,11 +49,12 @@ public class LocationServiceTest {
 	class RegisterLocation {
 		// Given
 		LocationRegisterRequest locationRegisterRequest
-				= new LocationRegisterRequest(
-				"프로그래머스 강남 교육장", "강남역 2번출구"
-				, locationTestUtils.getLatitude1(), locationTestUtils.getLongitude1(), "http://programmers_gangnam_image.com"
-				, Category.STUDY, "이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀...."
-				, locationTestUtils.getDayToVisit(), 4000, 1L
+			= new LocationRegisterRequest(
+			"프로그래머스 강남 교육장", "강남역 2번출구"
+			, locationTestUtils.getLatitude1(), locationTestUtils.getLongitude1(),
+			"http://programmers_gangnam_image.com"
+			, Category.STUDY, "이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀...."
+			, locationTestUtils.getDayToVisit(), 4000, 1L
 		);
 
 		@Test
@@ -60,7 +65,7 @@ public class LocationServiceTest {
 
 			// When
 			LocationRegisterResponse locationRegisterResponse =
-					locationService.registerLocation(locationRegisterRequest);
+				locationService.registerLocation(locationRegisterRequest);
 
 			// Then
 			assertThat(locationRegisterResponse.id()).isEqualTo(1L);
@@ -81,11 +86,11 @@ public class LocationServiceTest {
 
 			// When
 			LocationGetResponse locationGetResponse =
-					locationService.getLocation(1L);
+				locationService.getLocation(1L);
 
 			// Then
 			assertThat(locationGetResponse).usingRecursiveComparison()
-					.isEqualTo(toLocationGetResponse(locationTestUtils.getLocation()));
+				.isEqualTo(toLocationGetResponse(locationTestUtils.getLocation()));
 		}
 
 		@Test
@@ -96,7 +101,7 @@ public class LocationServiceTest {
 
 			// When // Then
 			assertThatThrownBy(
-					() -> locationService.getLocation(1L)
+				() -> locationService.getLocation(1L)
 			).isInstanceOf(EntityNotFoundException.class);
 		}
 	}
@@ -109,7 +114,7 @@ public class LocationServiceTest {
 		Long partyId = 1L;
 
 		LocationGetAllRequest locationGetAllRequest
-				= new LocationGetAllRequest(1L, pageSize, partyId);
+			= new LocationGetAllRequest(1L, pageSize, partyId);
 
 		List<Location> partyId1Locations = new ArrayList<>();
 
@@ -117,14 +122,15 @@ public class LocationServiceTest {
 		@DisplayName("해당 모임의 모든 후보 장소를 가져올 수 있다.")
 		void getAllLocationsTest() {
 			// Given
-			for (Location location : locationTestUtils.getLocations()){
-				if (partyId1Locations.size() >= 5) break;
+			for (Location location : locationTestUtils.getLocations()) {
+				if (partyId1Locations.size() >= 5)
+					break;
 				if (location.getPartyId() == 1L)
 					partyId1Locations.add(location);
 			}
 
 			given(locationRepository.findAllByPartyIdAndCursorIdLimitPageSize(1L, 1L, 5))
-					.willReturn(partyId1Locations);
+				.willReturn(partyId1Locations);
 
 			// When
 			LocationGetAllResponse locationGetAllResponse = locationService.getAllLocations(locationGetAllRequest);
@@ -133,11 +139,33 @@ public class LocationServiceTest {
 			assertThat(locationGetAllResponse.locations().size()).isEqualTo(5);
 			for (int i = 0; i < 4; i++) {
 				assertThat(locationGetAllResponse.locations().get(i)).usingRecursiveComparison()
-						.isEqualTo(toLocationGetResponse(locationTestUtils.getLocations().get(i)));
+					.isEqualTo(toLocationGetResponse(locationTestUtils.getLocations().get(i)));
 			}
 			assertThat(locationGetAllResponse.locations().get(4)).usingRecursiveComparison()
-					.isEqualTo(toLocationGetResponse(locationTestUtils.getLocations().get(5)));
+				.isEqualTo(toLocationGetResponse(locationTestUtils.getLocations().get(5)));
 		}
 
+	}
+
+	@Nested
+	@DisplayName("deleteRouteLocation을 사용해서 ")
+	class deleteRouteLocation {
+		// Given
+		Long locationId = 1L;
+
+		@Test
+		@DisplayName("루트에서 후보지를 삭제할 수 있다.")
+		void deleteRouteLocationTest() {
+			given(locationRepository.findById(any(Long.class))).
+				willReturn(Optional.of(locationTestUtils.getLocation()));
+
+			// When
+			locationService.deleteRouteLocation(locationId);
+
+			// Then
+			then(locationRepository)
+				.should()
+				.findById(any(Long.class));
+		}
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
@@ -15,6 +15,7 @@ import org.prgrms.wumo.domain.member.dto.request.MemberEmailCheckRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberLoginRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberNicknameCheckRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberRegisterRequest;
+import org.prgrms.wumo.domain.member.dto.request.MemberUpdateRequest;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -62,7 +63,7 @@ public class MemberControllerTest extends MysqlTestContainer {
 
 	@AfterEach
 	void tearDown() {
-		memberRepository.deleteAll();
+		memberRepository.deleteById(memberId);
 		SecurityContextHolder.clearContext();
 	}
 
@@ -157,6 +158,28 @@ public class MemberControllerTest extends MysqlTestContainer {
 			.andExpect(jsonPath("$.id").value(memberId))
 			.andExpect(jsonPath("$.email").value("taehee@gmail.com"))
 			.andExpect(jsonPath("$.nickname").value("태희"))
+			.andExpect(jsonPath("$.profileImage").isEmpty())
+			.andDo(print());
+	}
+
+	@Test
+	@DisplayName("내 정보를 수정한다")
+	void update_member() throws Exception {
+		//given
+		MemberUpdateRequest memberUpdateRequest
+			= new MemberUpdateRequest(memberId, "태희수정", "asd67890", null);
+
+		//when
+		ResultActions resultActions
+			= mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/members")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(memberUpdateRequest)));
+
+		//then
+		resultActions
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.id").value(memberId))
+			.andExpect(jsonPath("$.nickname").value("태희수정"))
 			.andExpect(jsonPath("$.profileImage").isEmpty())
 			.andDo(print());
 	}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 루트에서 후보지 삭제 기능 구현 및 테스트

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 후보지의 루트 상태를 삭제하기 위해 Location 객체에서 null로 변환후 dirty checking 하는 방식으로 구현하였습니다
null을 주입하는 방법이 옳은가 의문이 들기도 합니다
더 좋은 방법이 있을까 같이 고민해주시면 감사하겠습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-208], [WUMO-209]

[WUMO-208]: https://shoekream.atlassian.net/browse/WUMO-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-209]: https://shoekream.atlassian.net/browse/WUMO-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ