### PR TITLE
[WUMO-210] Route API 명세서에 요구사항 변경 반영

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteGetAllRequest.java
@@ -7,12 +7,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "루트 목록 조회 요청 정보")
 public record RouteGetAllRequest(
-	@Schema(description = "커서 식별자", required = false, example = "9")
+	@Schema(description = "커서 식별자", example = "9", required = false)
 	Long cursorId,
 
 	@NotNull
 	@Positive(message = "page size는 0 또는 음수일 수 없습니다.")
-	@Schema(description = "페이지 사이즈", required = true, example = "5")
+	@Schema(description = "페이지 사이즈", example = "5", required = true)
 	int pageSize
 
 	//기본 : 최신순, 좋아요순인지, 지난달 베스트 일정인지

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteRegisterRequest.java
@@ -6,15 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "루트에 후보지 등록 요청 정보")
 public record RouteRegisterRequest(
-	@Schema(description = "이미 루트가 존재할 경우의 루트 식별자(루트를 처음 생성한다면 null)", required = false, example = "1")
+	@Schema(description = "이미 루트가 존재할 경우의 루트 식별자(루트를 처음 생성한다면 null)", example = "1", required = false)
 	Long routeId,
 
 	@NotNull(message = "등록할 후보지를 선택해주세요.")
-	@Schema(description = "루트에 등록할 후보지 식별자", required = true, example = "1")
+	@Schema(description = "루트에 등록할 후보지 식별자", example = "1", required = true)
 	Long locationId,
 
 	@NotNull(message = "루트를 등록할 모임을 선택해주세요.")
-	@Schema(description = "루트를 등록할 모임 식별자", required = true, example = "1")
+	@Schema(description = "루트를 등록할 모임 식별자", example = "1", required = true)
 	Long partyId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteStatusUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteStatusUpdateRequest.java
@@ -7,10 +7,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "루트 공개여부 변경 요청 정보")
 public record RouteStatusUpdateRequest(
 	@NotNull(message = "공개할 루트를 선택해주세요.")
-	@Schema(description = "공개할 루트 식별자", required = true, example = "1")
+	@Schema(description = "공개할 루트 식별자", example = "1", required = true)
 	Long routeId,
 
-	@Schema(description = "루트 공개여부(true면 공개)", required = true, example = "true")
+	@Schema(description = "루트 공개여부(true면 공개)", example = "1", required = true)
 	boolean isPublic
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteStatusUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteStatusUpdateRequest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.route.dto.request;
 
+import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,6 +12,10 @@ public record RouteStatusUpdateRequest(
 	Long routeId,
 
 	@Schema(description = "루트 공개여부(true면 공개)", example = "1", required = true)
-	boolean isPublic
+	boolean isPublic,
+
+	@NotBlank(message = "루트 이름은 필수 입력사항입니다.")
+	@Schema(description = "루트 공개 시 보여줄 루트 이름", example = "퇴사 기념 여행", required = true)
+	String name
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
@@ -10,16 +10,16 @@ public record RouteGetAllResponse(
 	// @Schema(description = "루트의 좋아요 수", example = "10", required = true)
 	// long likeCount,
 
-	@Schema(description = "루트의 장소 이름들", example = "[{갈치 구이집}, {바다 카페}]", required = true)
+	@Schema(description = "루트의 장소 이름들", required = true)
 	List<RouteLocationSimpleResponse> locations,
 
 	@Schema(description = "루트 이름", example = "퇴사 기념 여행", required = true)
 	String name,
 
-	@Schema(description = "루트가 속한 모임 시작일", example = "퇴사 기념 여행", required = true)
+	@Schema(description = "루트가 속한 모임 시작일", example = "2023-02-21T10:00:00", required = true)
 	LocalDateTime startDate,
 
-	@Schema(description = "루트가 속한 모임 마지막일", example = "퇴사 기념 여행", required = true)
+	@Schema(description = "루트가 속한 모임 마지막일", example = "2023-02-25T10:00:00", required = true)
 	LocalDateTime endDate
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
@@ -20,6 +20,9 @@ public record RouteGetAllResponse(
 	LocalDateTime startDate,
 
 	@Schema(description = "루트가 속한 모임 마지막일", example = "2023-02-25T10:00:00", required = true)
-	LocalDateTime endDate
+	LocalDateTime endDate,
+
+	@Schema(description = "루트의 썸네일 이미지", example = "https://~", required = true)
+	String image
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteLocationResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteLocationResponse.java
@@ -4,39 +4,39 @@ import java.time.LocalDateTime;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(name = "루트의 일정 응답 정보")
+@Schema(name = "루트의 후보지 응답 정보")
 public record RouteLocationResponse(
-	@Schema(description = "후보장소 식별자", example = "1", required = true)
+	@Schema(description = "후보지 식별자", example = "1", required = true)
 	Long id,
 
-	@Schema(description = "후보장소 상호명", example = "오예스 식당", required = true)
+	@Schema(description = "후보지 상호명", example = "오예스 식당", required = true)
 	String name,
 
-	@Schema(description = "후보장소 주소", example = "부산광역시 수영구 ~~~ ", required = true)
+	@Schema(description = "후보지 주소", example = "부산광역시 수영구 ~~~ ", required = true)
 	String address,
 
-	@Schema(description = "후보장소 위도", example = "34.567890", required = true)
+	@Schema(description = "후보지 위도", example = "34.567890", required = true)
 	Float latitude,
 
-	@Schema(description = "후보장소 경도", example = "123.567890", required = true)
+	@Schema(description = "후보지 경도", example = "123.567890", required = true)
 	Float longitude,
 
-	@Schema(description = "후보장소 이미지", example = "https://~", required = true)
+	@Schema(description = "후보지 이미지", example = "https://~", required = true)
 	String image,
 
-	@Schema(description = "후보장소 설명", example = "딸기맛이 맛있다고함!", required = false)
+	@Schema(description = "후보지 설명", example = "딸기맛이 맛있다고함!", required = false)
 	String description,
 
-	@Schema(description = "후보장소 방문예정일", example = "2023-02-21T10:00:00", required = true)
+	@Schema(description = "후보지 방문예정일", example = "2023-02-21T10:00:00", required = true)
 	LocalDateTime visitDate,
 
-	@Schema(description = "후보장소 예상 지출", example = "55000", required = true)
+	@Schema(description = "후보지 예상 지출", example = "55000", required = true)
 	int expectedCost,
 
-	@Schema(description = "후보장소 실제 지출", example = "55000", required = false)
+	@Schema(description = "후보지 실제 지출", example = "55000", required = false)
 	int spending,
 
-	@Schema(description = "후보장소 카테고리", example = "MEAL", required = true)
+	@Schema(description = "후보지 카테고리", example = "MEAL", required = true)
 	String category
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteLocationSimpleResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteLocationSimpleResponse.java
@@ -2,17 +2,18 @@ package org.prgrms.wumo.domain.route.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(name = "(루트 목록에서)루트의 후보지 응답 정보")
 public record RouteLocationSimpleResponse(
-	@Schema(description = "후보장소 식별자", example = "1", required = true)
+	@Schema(description = "후보지 식별자", example = "1", required = true)
 	Long id,
 
-	@Schema(description = "후보장소 상호명", example = "오예스 식당", required = true)
+	@Schema(description = "후보지 상호명", example = "오예스 식당", required = true)
 	String name,
 
-	@Schema(description = "후보장소 주소", example = "부산광역시 수영구 ~~~ ", required = true)
+	@Schema(description = "후보지 주소", example = "부산광역시 수영구 ~~~ ", required = true)
 	String address,
 
-	@Schema(description = "후보장소 이미지", example = "https://~", required = true)
+	@Schema(description = "후보지 이미지", example = "https://~", required = true)
 	String image
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -56,7 +56,8 @@ public class RouteMapper {
 				toRouteLocationSimpleResponse(route.getLocations()),
 				route.getParty().getName(),
 				route.getParty().getStartDate(),
-				route.getParty().getEndDate())
+				route.getParty().getEndDate(),
+				route.getParty().getCoverImage())
 			)
 			.toList();
 		return new RouteGetAllResponses(routesResponses, lastId);

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -189,7 +189,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 	void update_route_public_status() throws Exception {
 		//given
 		RouteStatusUpdateRequest routeStatusUpdateRequest
-			= new RouteStatusUpdateRequest(routeId, true);
+			= new RouteStatusUpdateRequest(routeId, true, "퇴사 기념 여행");
 
 		//when
 		ResultActions resultActions

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -235,7 +235,7 @@ public class RouteServiceTest {
 	class UpdateRoutePublicStatus {
 		//given
 		RouteStatusUpdateRequest routeStatusUpdateRequest
-			= new RouteStatusUpdateRequest(routeId, true);
+			= new RouteStatusUpdateRequest(routeId, true, "퇴사 기념 여행");
 
 		Route route = getRouteData();
 


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 루트 API 명세서에 요구사항 변경 반영 및 단어 통일

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

프론트와 상의 후 

- 루트를 공개로 변경 시 사용할 루트의 이름을 회원에게 받기로 하였습니다(default 값은 루트가 속한 모임의 이름)
- 공개된 루트 목록에서 루트의 썸네일 이미지는 모임의 썸네일 이미지를 응답하기로 했습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-211], [WUMO-212]

[WUMO-211]: https://shoekream.atlassian.net/browse/WUMO-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-212]: https://shoekream.atlassian.net/browse/WUMO-212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ