### PR TITLE
[WUMO-91] PartyRouteComment 등록 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
@@ -4,11 +4,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentGetAllRequest;
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentUpdateRequest;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.service.PartyRouteCommentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -22,15 +24,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/party-route-comments")
+@RequiredArgsConstructor
 @Tag(name = "루트 댓글 api")
 public class RouteCommentController {
+
+	private final PartyRouteCommentService partyRouteCommentService;
 
 	@PostMapping
 	@Operation(summary = "모임 내 루트 댓글 생성")
 	public ResponseEntity<PartyRouteCommentRegisterResponse> registerPrivateRouteComment(
 			@RequestBody @Valid PartyRouteCommentRegisterRequest request
 	) {
-		return new ResponseEntity<>(null, HttpStatus.CREATED);
+		return new ResponseEntity<>(partyRouteCommentService.registerPartyRouteComment(request), HttpStatus.CREATED);
 	}
 
 	@GetMapping

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
@@ -29,7 +29,7 @@ public record PartyRouteCommentRegisterRequest(
 			Long memberId, String content, String image, Long routeId, Long locationId
 	) {
 		if (content.isEmpty() && image.isEmpty()) {
-			throw new ValidationException("");
+			throw new ValidationException("댓글에 이미지나 내용 둘 중 하나는 있어야 합니다.");
 		}
 
 		this.memberId = memberId;

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 
-@Schema(name = "모임 내 루트 댓글 생성 요청")
+@Schema(name = "모임 내 일정 댓글 생성 요청")
 public record PartyRouteCommentRegisterRequest(
 
 		@NotNull(message = "댓글 성성 요청자의 id는 필수 입력값입니다")
@@ -17,12 +17,16 @@ public record PartyRouteCommentRegisterRequest(
 		@Schema(description = "댓글 사진 링크", example = "http://", required = true)
 		String image,
 
-		@NotNull(message = "댓글이 쓰여지는 경로의 id는 필수 입력값입니다.")
+		@NotNull(message = "댓글이 쓰여지는 일정의 id는 필수 입력값입니다.")
 		@Schema(description = "루트 id", example = "1", required = true)
-		Long routeId
+		Long routeId,
+
+		@NotNull(message = "댓글이 쓰여지는 일정에서의 장소 id는 필수 입력값입니다. ")
+		@Schema(description = "", example = "1", required = true)
+		Long locationId
 ) {
 	public PartyRouteCommentRegisterRequest(
-			Long memberId, String content, String image, Long routeId
+			Long memberId, String content, String image, Long routeId, Long locationId
 	) {
 		if (content.isEmpty() && image.isEmpty()) {
 			throw new ValidationException("");
@@ -32,5 +36,6 @@ public record PartyRouteCommentRegisterRequest(
 		this.content = content;
 		this.image = image;
 		this.routeId = routeId;
+		this.locationId = locationId;
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/model/PartyRouteComment.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/model/PartyRouteComment.java
@@ -23,15 +23,23 @@ public class PartyRouteComment extends Comment {
 	@Column(name = "route_id", nullable = false, updatable = true, unique = false)
 	private Long routeId;
 
+	@Column(name = "location_id", nullable = false, updatable = false, unique = false)
+	private Long locationId;
+
 	@OneToOne
 	@JoinColumn(name = "party_member_id")
 	private PartyMember partyMember;
 
 	@Builder
 	public PartyRouteComment(Long id, Member member, String content, String image, Long routeId,
-			PartyMember partyMember, boolean isEdited) {
+			PartyMember partyMember, boolean isEdited, Long locationId) {
 		super(id, member, content, image, isEdited);
 		this.routeId = routeId;
+		this.partyMember = partyMember;
+		this.locationId = locationId;
+	}
+
+	public void setPartyMember(PartyMember partyMember) {
 		this.partyMember = partyMember;
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/repository/PartyRouteCommentRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/repository/PartyRouteCommentRepository.java
@@ -1,0 +1,7 @@
+package org.prgrms.wumo.domain.comment.repository;
+
+import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PartyRouteCommentRepository extends JpaRepository<PartyRouteComment, Long> {
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
@@ -1,0 +1,72 @@
+package org.prgrms.wumo.domain.comment.service;
+
+import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
+import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteComment;
+import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentRegisterResponse;
+import javax.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
+import org.prgrms.wumo.domain.comment.repository.PartyRouteCommentRepository;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PartyRouteCommentService {
+
+	private final PartyRouteCommentRepository partyRouteCommentRepository;
+	private final MemberRepository memberRepository;
+	private final PartyMemberRepository partyMemberRepository;
+	private final RouteRepository routeRepository;
+	private final LocationRepository locationRepository;
+
+	@Transactional
+	public PartyRouteCommentRegisterResponse registerPartyRouteComment(
+			PartyRouteCommentRegisterRequest partyRouteCommentRegisterRequest) {
+
+		PartyRouteComment partyRouteComment = toPartyRouteComment(partyRouteCommentRegisterRequest);
+
+		partyRouteComment.setMember(getMemberEntity(getMemberId()));
+
+		partyRouteComment.setPartyMember(
+				getPartyMemberEntity(
+						getRouteEntity(
+								partyRouteCommentRegisterRequest.routeId()).getParty().getId(),
+						getMemberId()
+				)
+		);
+
+		validateLocation(partyRouteCommentRegisterRequest.locationId());
+
+		return toPartyRouteCommentRegisterResponse(
+				partyRouteCommentRepository.save(partyRouteComment)
+		);
+	}
+
+	private Member getMemberEntity(Long memberId) {
+		return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("존재 하지 않는 회원입니다"));
+	}
+
+	private Route getRouteEntity(Long routeId) {
+		return routeRepository.findById(routeId).orElseThrow(() -> new EntityNotFoundException("루트가 존재하지 않습니다"));
+	}
+
+	private PartyMember getPartyMemberEntity(Long partyId, Long memberId) {
+		return partyMemberRepository.findByPartyIdAndMemberId(partyId, memberId)
+				.orElseThrow(() -> new EntityNotFoundException("모임 내 존재하지 않는 회원입니다"));
+	}
+
+	private void validateLocation(Long locationId){
+		if (!locationRepository.existsById(locationId))
+			throw new EntityNotFoundException("댓글을 작성하고자 하는 후보지가 존재하지 않습니다");
+	}
+}

--- a/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
@@ -2,10 +2,13 @@ package org.prgrms.wumo.global.mapper;
 
 import java.util.List;
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentGetResponse;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
 import org.prgrms.wumo.domain.comment.model.LocationComment;
+import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
 
 public class CommentMapper {
 	public static LocationCommentRegisterResponse toLocationCommentRegisterResponse(LocationComment locationcomment) {
@@ -42,6 +45,22 @@ public class CommentMapper {
 				locationComments.stream().map(CommentMapper::toLocationCommentGetResponse).toList(),
 				lastId
 		);
+	}
+
+	public static PartyRouteCommentRegisterResponse toPartyRouteCommentRegisterResponse(PartyRouteComment partyRouteComment){
+		return new PartyRouteCommentRegisterResponse(
+				partyRouteComment.getId()
+		);
+	}
+
+
+	public static PartyRouteComment toPartyRouteComment(PartyRouteCommentRegisterRequest partyRouteCommentRegisterRequest){
+		return PartyRouteComment.builder()
+				.locationId(partyRouteCommentRegisterRequest.locationId())
+				.routeId(partyRouteCommentRegisterRequest.routeId())
+				.content(partyRouteCommentRegisterRequest.content())
+				.image(partyRouteCommentRegisterRequest.image())
+				.build();
 	}
 
 }

--- a/src/main/resources/db/migration/V6__alter_party_route_comment_add_location_id.sql
+++ b/src/main/resources/db/migration/V6__alter_party_route_comment_add_location_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `party_route_comment`
+    ADD COLUMN `location_id` BIGINT NOT NULL;

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -150,14 +150,14 @@ public class PartyRouteCommentControllerTest {
 	void registerPartyRouteCommentTest() throws Exception {
 		// Given
 		PartyRouteCommentRegisterRequest request = new PartyRouteCommentRegisterRequest(
-				1L, "모임 내 댓글", "image.png", 1L, 1L
+				member.getId(), "모임 내 댓글", "image.png", route.getId(), location.getId()
 		);
 
 		// When
 		ResultActions resultActions =
 				mockMvc.perform(
 						post("/api/v1/party-route-comments")
-								.contentType(MediaType.APPLICATION_JSON)
+								.contentType(MediaType.APPLICATION_JSON_VALUE)
 								.characterEncoding("UTF-8")
 								.content(
 										objectMapper.writeValueAsString(request)

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
@@ -69,6 +70,8 @@ public class PartyRouteCommentControllerTest {
 	Location location;
 	Route route;
 
+	List<Location> locations = new ArrayList<>();
+
 	@BeforeEach
 	void beforeEach() {
 		member = memberRepository.save(
@@ -115,10 +118,12 @@ public class PartyRouteCommentControllerTest {
 						.build()
 		);
 
+		locations.add(location);
+
 		route = routeRepository.save(
 				Route.builder()
 						.party(party)
-						.locations(List.of())
+						.locations(locations)
 						.build()
 		);
 
@@ -131,9 +136,9 @@ public class PartyRouteCommentControllerTest {
 
 	@AfterEach
 	void afterEach() {
+		routeRepository.deleteById(route.getId());
 		locationRepository.deleteById(location.getId());
 		partyMemberRepository.deleteById(partyMember.getId());
-		routeRepository.deleteById(route.getId());
 		partyRepository.deleteById(party.getId());
 		memberRepository.deleteById(member.getId());
 

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -1,0 +1,168 @@
+package org.prgrms.wumo.domain.comment.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("PartyRouteCommentController를 통해 ")
+public class PartyRouteCommentControllerTest {
+
+	@Autowired
+	MockMvc mockMvc;
+
+	@Autowired
+	ObjectMapper objectMapper;
+
+	@Autowired
+	MemberRepository memberRepository;
+
+	@Autowired
+	PartyRepository partyRepository;
+
+	@Autowired
+	LocationRepository locationRepository;
+
+	@Autowired
+	PartyMemberRepository partyMemberRepository;
+
+	@Autowired
+	RouteRepository routeRepository;
+
+	// GIVEN
+	Member member;
+	Party party;
+	PartyMember partyMember;
+	Location location;
+	Route route;
+
+	@BeforeEach
+	void beforeEach() {
+		member = memberRepository.save(
+				Member.builder()
+						.password("qwe12345")
+						.email("member@email.com")
+						.nickname("nickname")
+						.build()
+		);
+
+		party = partyRepository.save(
+				Party.builder()
+						//.id(1L)
+						.password("1234").description("오예스팀 모임")
+						.coverImage("party_cover_image.png")
+						.name("오예스")
+						.startDate(LocalDateTime.now().plusDays(2))
+						.endDate(LocalDateTime.now().plusDays(5))
+						.build()
+		);
+
+		partyMember = partyMemberRepository.save(
+				PartyMember.builder()
+						.member(member)
+						.party(party)
+						.role("총무")
+						.isLeader(true)
+						.build()
+		);
+
+		location = locationRepository.save(
+				Location.builder()
+						.category(Category.COFFEE)
+						.visitDate(LocalDateTime.now().plusDays(4))
+						.description("아인슈페너가 맛있는 곳!")
+						.name("cafe")
+						.address("경기도 고양시")
+						.latitude(12.34F)
+						.longitude(34.56F)
+						.partyId(party.getId())
+						.expectedCost(4000)
+						.spending(3500)
+						.image("image.url")
+						.build()
+		);
+
+		route = routeRepository.save(
+				Route.builder()
+						.party(party)
+						.locations(List.of())
+						.build()
+		);
+
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(member.getId(), null, Collections.EMPTY_LIST);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@AfterEach
+	void afterEach() {
+		locationRepository.deleteById(location.getId());
+		partyMemberRepository.deleteById(partyMember.getId());
+		routeRepository.deleteById(route.getId());
+		partyRepository.deleteById(party.getId());
+		memberRepository.deleteById(member.getId());
+
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("모임 내 일정에 댓글을 생성할 수 있다")
+	void registerPartyRouteCommentTest() throws Exception {
+		// Given
+		PartyRouteCommentRegisterRequest request = new PartyRouteCommentRegisterRequest(
+				1L, "모임 내 댓글", "image.png", 1L, 1L
+		);
+
+		// When
+		ResultActions resultActions =
+				mockMvc.perform(
+						post("/api/v1/party-route-comments")
+								.contentType(MediaType.APPLICATION_JSON)
+								.characterEncoding("UTF-8")
+								.content(
+										objectMapper.writeValueAsString(request)
+								)
+				);
+
+		// Then
+		resultActions
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.id").isNotEmpty())
+				.andDo(print());
+	}
+}

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
@@ -1,0 +1,180 @@
+package org.prgrms.wumo.domain.comment.service;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
+import org.prgrms.wumo.domain.comment.repository.PartyRouteCommentRepository;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayName("PartyRouteCommentService 에서")
+@ExtendWith(MockitoExtension.class)
+public class PartyRouteCommentServiceTest {
+
+	@InjectMocks
+	PartyRouteCommentService partyRouteCommentService;
+
+	@Mock
+	PartyRouteCommentRepository partyRouteCommentRepository;
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	PartyMemberRepository partyMemberRepository;
+
+	@Mock
+	LocationRepository locationRepository;
+
+	@Mock
+	RouteRepository routeRepository;
+
+	// GIVEN
+	Member member;
+	Party party;
+	PartyMember partyMember;
+	PartyRouteComment partyRouteComment;
+	Route route;
+	Location location;
+
+	@BeforeEach
+	void beforeEach() {
+		member = getMember();
+		party = getParty();
+		partyMember = getPartyMember();
+		partyRouteComment = getPartyRouteComment();
+		route = getRoute();
+		location = getLocation();
+
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(1L, null, Collections.EMPTY_LIST);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@AfterEach
+	void afterEach() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Nested
+	@DisplayName("registerPartyRouteComment를 통해 ")
+	class registerPartyRouteComment{
+		@Test
+		@DisplayName("모임 내 일정에 댓글을 등록한다")
+		void success(){
+			// Given
+			PartyRouteCommentRegisterRequest request = new PartyRouteCommentRegisterRequest(
+					1L, "모임 내 댓글", "image.png", 1L, 1L
+			);
+
+			given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(member));
+			given(partyMemberRepository.findByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(Optional.of(partyMember));
+			given(routeRepository.findById(any(Long.class))).willReturn(Optional.of(route));
+			given(locationRepository.existsById(any(Long.class))).willReturn(true);
+			given(partyRouteCommentRepository.save(any(PartyRouteComment.class))).willReturn(partyRouteComment);
+
+			// When
+			PartyRouteCommentRegisterResponse response =
+					partyRouteCommentService.registerPartyRouteComment(request);
+
+			// Then
+			assertThat(response.id()).isEqualTo(1L);
+		}
+	}
+
+	private Member getMember() {
+		return Member.builder()
+				.id(1L)
+				.password("qwe12345")
+				.email("member@email.com")
+				.nickname("nickname")
+				.build();
+	}
+
+	private Party getParty() {
+		return Party.builder()
+				.id(1L)
+				.password("1234").description("오예스팀 모임")
+				.coverImage("party_cover_image.png")
+				.name("오예스")
+				.endDate(LocalDateTime.now().plusDays(5))
+				.startDate(LocalDateTime.now().plusDays(2))
+				.build();
+	}
+
+	private PartyMember getPartyMember() {
+		return PartyMember.builder()
+				.id(1L)
+				.member(member)
+				.party(party)
+				.role("총무")
+				.isLeader(true)
+				.build();
+	}
+
+	private PartyRouteComment getPartyRouteComment() {
+		return PartyRouteComment.builder()
+				.id(1L)
+				.routeId(1L)
+				.partyMember(partyMember)
+				.image("image.png")
+				.content("모임 내 댓글")
+				.isEdited(false)
+				.locationId(1L)
+				.member(member)
+				.build();
+	}
+
+	private Route getRoute(){
+		return Route.builder()
+				.id(1L)
+				.party(party)
+				.locations(List.of())
+				.build();
+	}
+
+	private Location getLocation(){
+		return Location.builder()
+				.id(1L)
+				.partyId(party.getId())
+				.expectedCost(50000)
+				.spending(45000)
+				.address("경기도 고양시 일산서구")
+				.name("내 집")
+				.description("언제 와도 좋은 서윗한 내 집")
+				.longitude(12.34F)
+				.latitude(67.89F)
+				.category(Category.DRINK)
+				.visitDate(LocalDateTime.now())
+				.build();
+	}
+}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

PartyRouteComment 등록 기능 구현 및 테스트

### ⛏ 중점 사항

이전에 PartyRouteComment 는 Location Id 를 필드로 들고 있지 않아도 연관관계를 이용해서 작성하려 했으나, 
있어야겠다고 판단, 칼럼을 추가했습니다.

명세서 등의 용어 통일 은 추후 다른 작업에서 진행할 예정입니다

### 💡 관련 이슈

- Resolved : WUMO-91