### PR TITLE
[WUMO-144] Token 재발급 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
@@ -6,6 +6,7 @@ import org.prgrms.wumo.domain.member.dto.request.MemberEmailCheckRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberLoginRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberNicknameCheckRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberRegisterRequest;
+import org.prgrms.wumo.domain.member.dto.request.MemberReissueRequest;
 import org.prgrms.wumo.domain.member.dto.request.MemberUpdateRequest;
 import org.prgrms.wumo.domain.member.dto.response.MemberGetResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberLoginResponse;
@@ -74,8 +75,18 @@ public class MemberController {
 	@DeleteMapping("/logout")
 	@Operation(summary = "로그아웃")
 	public ResponseEntity<Void> logoutMember() {
+
 		memberService.logoutMember();
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/reissue")
+	@Operation(summary = "토큰 재발급")
+	public ResponseEntity<MemberLoginResponse> reissueMember(
+		@RequestBody @Valid MemberReissueRequest memberReissueRequest
+	) {
+
+		return ResponseEntity.ok(memberService.reissueMember(memberReissueRequest));
 	}
 
 	@GetMapping("/{memberId}")

--- a/src/main/java/org/prgrms/wumo/domain/member/dto/request/MemberReissueRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/dto/request/MemberReissueRequest.java
@@ -1,0 +1,13 @@
+package org.prgrms.wumo.domain.member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "회원 토큰 재발급 요청 정보")
+public record MemberReissueRequest(
+	@Schema(description = "액세스토큰", example = "토큰값", requiredMode = Schema.RequiredMode.REQUIRED)
+	String accessToken,
+
+	@Schema(description = "리프레시토큰", example = "토큰값", requiredMode = Schema.RequiredMode.REQUIRED)
+	String refreshToken
+) {
+}

--- a/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.prgrms.wumo.global.exception.custom.DuplicateException;
 import org.prgrms.wumo.global.exception.custom.ExpiredInvitationException;
 import org.prgrms.wumo.global.exception.custom.ImageDeleteFailedException;
 import org.prgrms.wumo.global.exception.custom.ImageUploadFailedException;
+import org.prgrms.wumo.global.exception.custom.InvalidRefreshTokenException;
 import org.prgrms.wumo.global.exception.custom.PartyNotEmptyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler({
-		AccessDeniedException.class
+		AccessDeniedException.class, InvalidRefreshTokenException.class
 	})
 	public ResponseEntity<ExceptionResponse> handleAccessException(RuntimeException runtimeException) {
 		log.info("exception : " + runtimeException);
@@ -39,7 +40,7 @@ public class GlobalExceptionHandler {
 
 	@ExceptionHandler({
 		ImageUploadFailedException.class, IllegalArgumentException.class, ImageDeleteFailedException.class,
-			EntityNotFoundException.class, PartyNotEmptyException.class, ExpiredInvitationException.class
+		EntityNotFoundException.class, PartyNotEmptyException.class, ExpiredInvitationException.class
 	})
 	public ResponseEntity<ExceptionResponse> handleException(RuntimeException runtimeException) {
 		log.info("exception : " + runtimeException);

--- a/src/main/java/org/prgrms/wumo/global/exception/custom/InvalidRefreshTokenException.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/custom/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package org.prgrms.wumo.global.exception.custom;
+
+public class InvalidRefreshTokenException extends InvalidTokenException {
+	public InvalidRefreshTokenException() {
+	}
+
+	public InvalidRefreshTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/org/prgrms/wumo/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/prgrms/wumo/global/jwt/JwtTokenProvider.java
@@ -46,27 +46,6 @@ public class JwtTokenProvider {
 			.build();
 	}
 
-	private String generateAccessToken(String memberId, Date currentDate) {
-		Date expireDate = new Date(currentDate.getTime() + ACCESS_TOKEN_EXPIRE_SECONDS);
-
-		return Jwts.builder()
-			.setIssuer(issuer)
-			.setSubject(memberId)
-			.setIssuedAt(new Date())
-			.setExpiration(expireDate)
-			.signWith(secretKey)
-			.compact();
-	}
-
-	private String generateRefreshToken(Date currentDate) {
-		Date expireDate = new Date(currentDate.getTime() + REFRESH_TOKEN_EXPIRE_SECONDS);
-
-		return Jwts.builder()
-			.setExpiration(expireDate)
-			.signWith(secretKey)
-			.compact();
-	}
-
 	public Authentication getAuthentication(String accessToken) {
 		Claims claims = parseClaims(accessToken);
 		return new UsernamePasswordAuthenticationToken(
@@ -86,6 +65,31 @@ public class JwtTokenProvider {
 			log.info("Invalid JWT Token.", exception);
 			throw new InvalidTokenException("올바르지 않은 토큰입니다.");
 		}
+	}
+
+	public String extractMember(String accessToken) {
+		return parseClaims(accessToken).getSubject();
+	}
+
+	private String generateAccessToken(String memberId, Date currentDate) {
+		Date expireDate = new Date(currentDate.getTime() + ACCESS_TOKEN_EXPIRE_SECONDS);
+
+		return Jwts.builder()
+			.setIssuer(issuer)
+			.setSubject(memberId)
+			.setIssuedAt(new Date())
+			.setExpiration(expireDate)
+			.signWith(secretKey)
+			.compact();
+	}
+
+	private String generateRefreshToken(Date currentDate) {
+		Date expireDate = new Date(currentDate.getTime() + REFRESH_TOKEN_EXPIRE_SECONDS);
+
+		return Jwts.builder()
+			.setExpiration(expireDate)
+			.signWith(secretKey)
+			.compact();
 	}
 
 	private Claims parseClaims(String accessToken) {


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- token 재발급 기능 구현
- access token 만료 시 refresh token 검증 후 token 재발급

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- token 저장위치를 Redis로 변경 예정입니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-239], [WUMO-240]

[WUMO-239]: https://shoekream.atlassian.net/browse/WUMO-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-240]: https://shoekream.atlassian.net/browse/WUMO-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ