### PR TITLE
[WUMO-58] RouteLike 등록 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/like/controller/RouteLikeController.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/controller/RouteLikeController.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.like.controller;
 
+import org.prgrms.wumo.domain.like.service.RouteLikeService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -19,11 +20,14 @@ import lombok.RequiredArgsConstructor;
 @Tag(name = "루트 좋아요 API")
 public class RouteLikeController {
 
+	private final RouteLikeService routeLikeService;
+
 	@PostMapping("/{routeId}/likes")
 	@Operation(summary = "루트 좋아요 등록")
 	public ResponseEntity<Void> registerRouteLike(
 			@PathVariable @Parameter(description = "루트 식별자", required = true) Long routeId
 	) {
+		routeLikeService.registerRouteLike(routeId);
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeRepository.java
@@ -1,0 +1,10 @@
+package org.prgrms.wumo.domain.like.repository;
+
+import org.prgrms.wumo.domain.like.model.RouteLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RouteLikeRepository extends JpaRepository<RouteLike, Long> {
+
+	boolean existsByRouteIdAndMemberId(Long routeId, Long memberId);
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/like/service/RouteLikeService.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/service/RouteLikeService.java
@@ -1,0 +1,51 @@
+package org.prgrms.wumo.domain.like.service;
+
+import static org.prgrms.wumo.global.mapper.LikeMapper.toRouteLike;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.prgrms.wumo.global.exception.custom.DuplicateException;
+import org.prgrms.wumo.global.jwt.JwtUtil;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RouteLikeService {
+
+	private final MemberRepository memberRepository;
+
+	private final RouteRepository routeRepository;
+
+	private final RouteLikeRepository routeLikeRepository;
+
+	@Transactional
+	public void registerRouteLike(Long routeId) {
+		Route route = getRouteEntity(routeId);
+		Member member = getMemberEntity(JwtUtil.getMemberId());
+
+		if (routeLikeRepository.existsByRouteIdAndMemberId(route.getId(), member.getId())) {
+			throw new DuplicateException("이미 좋아요를 누른 루트입니다.");
+		}
+
+		routeLikeRepository.save(toRouteLike(route, member));
+	}
+
+	private Route getRouteEntity(Long routeId) {
+		return routeRepository.findById(routeId)
+				.orElseThrow(() -> new EntityNotFoundException("일치하는 루트가 없습니다."));
+	}
+
+	private Member getMemberEntity(Long memberId) {
+		return memberRepository.findById(memberId)
+				.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/global/mapper/LikeMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/LikeMapper.java
@@ -1,0 +1,20 @@
+package org.prgrms.wumo.global.mapper;
+
+import org.prgrms.wumo.domain.like.model.RouteLike;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.route.model.Route;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class LikeMapper {
+
+	public static RouteLike toRouteLike(Route route, Member member) {
+		return RouteLike.builder()
+				.routeId(route.getId())
+				.memberId(member.getId())
+				.build();
+	}
+
+}

--- a/src/test/java/org/prgrms/wumo/domain/like/controller/RouteLikeControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/like/controller/RouteLikeControllerTest.java
@@ -1,0 +1,138 @@
+package org.prgrms.wumo.domain.like.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.prgrms.wumo.MysqlTestContainer;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("RouteLikeController 를 통해 ")
+class RouteLikeControllerTest extends MysqlTestContainer {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private PartyRepository partyRepository;
+
+	@Autowired
+	private LocationRepository locationRepository;
+
+	@Autowired
+	private RouteRepository routeRepository;
+
+	//given
+	Member member;
+	Party party;
+	Location location;
+	Route route;
+
+	@BeforeEach
+	void setup() {
+		member = memberRepository.save(
+				Member.builder()
+						.email("ted-chang@gmail.com")
+						.password("qwe12345")
+						.nickname("테드창")
+						.build()
+		);
+		party = partyRepository.save(
+				Party.builder()
+						.name("오예스 워크샵")
+						.startDate(LocalDateTime.now())
+						.endDate(LocalDateTime.now().plusDays(1))
+						.description("팀 설립 기념 워크샵")
+						.coverImage("https://~.jpeg")
+						.password("1234")
+						.build()
+		);
+		location = locationRepository.save(
+				Location.builder()
+						.category(Category.STUDY)
+						.name("프로그래머스 대륭 서초 타워")
+						.description("그렙!!")
+						.latitude(12.123F)
+						.longitude(12.123F)
+						.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
+						.searchAddress("서울특별시")
+						.visitDate(LocalDateTime.now())
+						.image("http://grepp_image")
+						.spending(10000)
+						.expectedCost(10000)
+						.partyId(party.getId())
+						.build()
+		);
+		route = routeRepository.save(
+				Route.builder()
+						.id(1L)
+						.locations(List.of(location))
+						.party(party)
+						.build()
+		);
+		route.updatePublicStatus(true);
+		route = routeRepository.save(route);
+
+		setAuthentication(member.getId());
+	}
+
+	@AfterEach
+	void clean() {
+		locationRepository.deleteById(location.getId());
+		routeRepository.deleteById(route.getId());
+		partyRepository.deleteById(party.getId());
+		memberRepository.deleteById(member.getId());
+		SecurityContextHolder.clearContext();
+	}
+
+	@Test
+	@DisplayName("루트에 좋아요를 누를 수 있다.")
+	void validateInvitation() throws Exception {
+		//when
+		ResultActions resultActions = mockMvc.perform(post("/api/v1/routes/{routeId}/likes", route.getId()));
+
+		//then
+		resultActions
+				.andExpect(status().isCreated())
+				.andDo(print());
+	}
+
+	private void setAuthentication(Long memberId) {
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+}

--- a/src/test/java/org/prgrms/wumo/domain/like/service/RouteLikeServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/like/service/RouteLikeServiceTest.java
@@ -1,0 +1,166 @@
+package org.prgrms.wumo.domain.like.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.like.model.RouteLike;
+import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.prgrms.wumo.global.exception.custom.DuplicateException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("RouteLikeService 의")
+class RouteLikeServiceTest {
+
+	@Mock
+	MemberRepository memberRepository;
+
+	@Mock
+	RouteRepository routeRepository;
+
+	@Mock
+	RouteLikeRepository routeLikeRepository;
+
+	@InjectMocks
+	RouteLikeService routeLikeService;
+
+	//given
+	Member member;
+	Party party;
+	Location location;
+	Route route;
+
+	@BeforeEach
+	void setUp() {
+		member = Member.builder()
+				.id(1L)
+				.email("5yes@gmail.com")
+				.nickname("오예스오리지널")
+				.password("qwe12345")
+				.build();
+		party = Party.builder()
+				.id(1L)
+				.name("오예스 워크샵")
+				.startDate(LocalDateTime.now())
+				.endDate(LocalDateTime.now().plusDays(1))
+				.description("팀 설립 기념 워크샵")
+				.coverImage("https://~.jpeg")
+				.password("1234")
+				.build();
+		location = Location.builder()
+				.id(1L)
+				.category(Category.STUDY)
+				.name("프로그래머스 대륭 서초 타워")
+				.description("그렙!!")
+				.latitude(12.123F)
+				.longitude(12.123F)
+				.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
+				.searchAddress("서울특별시")
+				.visitDate(LocalDateTime.now())
+				.image("http://grepp_image")
+				.spending(10000)
+				.expectedCost(10000)
+				.partyId(party.getId())
+				.build();
+		route = Route.builder()
+				.id(1L)
+				.locations(List.of(location))
+				.party(party)
+				.build();
+
+		setAuthentication(member.getId());
+	}
+
+	@Nested
+	@DisplayName("registerRouteLike 메소드는 등록 요청시")
+	class RegisterInvitation {
+
+		@Test
+		@DisplayName("사용자가 좋아요를 누르지 않은 루트라면 좋아요를 등록한다.")
+		void success() {
+			//mocking
+			given(memberRepository.findById(member.getId()))
+					.willReturn(Optional.of(member));
+			given(routeRepository.findById(route.getId()))
+					.willReturn(Optional.of(route));
+			given(routeLikeRepository.existsByRouteIdAndMemberId(route.getId(), member.getId()))
+					.willReturn(false);
+
+			//when
+			routeLikeService.registerRouteLike(route.getId());
+
+			//then
+			then(memberRepository)
+					.should()
+					.findById(member.getId());
+			then(routeRepository)
+					.should()
+					.findById(route.getId());
+			then(routeLikeRepository)
+					.should()
+					.existsByRouteIdAndMemberId(route.getId(), member.getId());
+			then(routeLikeRepository)
+					.should()
+					.save(any(RouteLike.class));
+		}
+
+		@Test
+		@DisplayName("이미 사용자가 좋아요를 누른 루트면 예외가 발생한다.")
+		void failed() {
+			//mocking
+			given(memberRepository.findById(member.getId()))
+					.willReturn(Optional.of(member));
+			given(routeRepository.findById(route.getId()))
+					.willReturn(Optional.of(route));
+			given(routeLikeRepository.existsByRouteIdAndMemberId(route.getId(), member.getId()))
+					.willReturn(true);
+
+			//when
+			//then
+			Assertions.assertThrows(DuplicateException.class, () -> routeLikeService.registerRouteLike(route.getId()));
+
+			then(memberRepository)
+					.should()
+					.findById(member.getId());
+			then(routeRepository)
+					.should()
+					.findById(route.getId());
+			then(routeLikeRepository)
+					.should()
+					.existsByRouteIdAndMemberId(route.getId(), member.getId());
+		}
+
+	}
+
+	private void setAuthentication(Long memberId) {
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(memberId, null, Collections.emptyList());
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- RouteLike 등록 기능 구현 및 테스트

### ⛏ 중점 사항

- 좋아요 등록 과정에서 다음과 같은 검증이 이루어집니다.
  - 존재하는 루트 및 사용자 인가
  - 이미 해당 루트에 좋아요를 누른 사용자 인가

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-251], [WUMO-252]

[WUMO-251]: https://shoekream.atlassian.net/browse/WUMO-251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-252]: https://shoekream.atlassian.net/browse/WUMO-252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ