### PR TITLE
[WUMO-63] RouteLike 삭제 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/like/controller/RouteLikeController.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/controller/RouteLikeController.java
@@ -31,11 +31,12 @@ public class RouteLikeController {
 		return new ResponseEntity<>(HttpStatus.CREATED);
 	}
 
-	@DeleteMapping("/{routeId}/unlikes")
+	@DeleteMapping("/{routeId}/likes")
 	@Operation(summary = "루트 좋아요 삭제")
 	public ResponseEntity<Void> deleteRouteLike(
 			@PathVariable @Parameter(description = "루트 식별자", required = true) Long routeId
 	) {
+		routeLikeService.deleteRouteLike(routeId);
 		return new ResponseEntity<>(HttpStatus.OK);
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeRepository.java
@@ -2,9 +2,15 @@ package org.prgrms.wumo.domain.like.repository;
 
 import org.prgrms.wumo.domain.like.model.RouteLike;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RouteLikeRepository extends JpaRepository<RouteLike, Long> {
 
 	boolean existsByRouteIdAndMemberId(Long routeId, Long memberId);
+
+	@Modifying
+	@Query("DELETE FROM RouteLike routeLike WHERE routeLike.routeId = :routeId AND routeLike.memberId = :memberId")
+	int deleteByRouteIdAndMemberId(Long routeId, Long memberId);
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/like/service/RouteLikeService.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/service/RouteLikeService.java
@@ -38,6 +38,16 @@ public class RouteLikeService {
 		routeLikeRepository.save(toRouteLike(route, member));
 	}
 
+	@Transactional
+	public void deleteRouteLike(Long routeId) {
+		Route route = getRouteEntity(routeId);
+		Member member = getMemberEntity(JwtUtil.getMemberId());
+
+		if (routeLikeRepository.deleteByRouteIdAndMemberId(route.getId(), member.getId()) == 0) {
+			throw new EntityNotFoundException("좋아요를 누르지 않은 루트의 좋아요를 취소할 수 없습니다.");
+		}
+	}
+
 	private Route getRouteEntity(Long routeId) {
 		return routeRepository.findById(routeId)
 				.orElseThrow(() -> new EntityNotFoundException("일치하는 루트가 없습니다."));

--- a/src/test/java/org/prgrms/wumo/domain/like/controller/RouteLikeControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/like/controller/RouteLikeControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.like.controller;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgrms.wumo.MysqlTestContainer;
+import org.prgrms.wumo.domain.like.model.RouteLike;
+import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
 import org.prgrms.wumo.domain.location.model.Category;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
@@ -52,6 +55,9 @@ class RouteLikeControllerTest extends MysqlTestContainer {
 
 	@Autowired
 	private RouteRepository routeRepository;
+
+	@Autowired
+	private RouteLikeRepository routeLikeRepository;
 
 	//given
 	Member member;
@@ -118,13 +124,33 @@ class RouteLikeControllerTest extends MysqlTestContainer {
 
 	@Test
 	@DisplayName("루트에 좋아요를 누를 수 있다.")
-	void validateInvitation() throws Exception {
+	void registerRouteLike() throws Exception {
 		//when
 		ResultActions resultActions = mockMvc.perform(post("/api/v1/routes/{routeId}/likes", route.getId()));
 
 		//then
 		resultActions
 				.andExpect(status().isCreated())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("루트에 좋아요를 삭제할 수 있다.")
+	void deleteRouteLike() throws Exception {
+		//given
+		routeLikeRepository.save(
+				RouteLike.builder()
+						.routeId(route.getId())
+						.memberId(member.getId())
+						.build()
+		);
+
+		//when
+		ResultActions resultActions = mockMvc.perform(delete("/api/v1/routes/{routeId}/likes", route.getId()));
+
+		//then
+		resultActions
+				.andExpect(status().isOk())
 				.andDo(print());
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/like/service/RouteLikeServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/like/service/RouteLikeServiceTest.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import javax.persistence.EntityNotFoundException;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -97,7 +99,7 @@ class RouteLikeServiceTest {
 
 	@Nested
 	@DisplayName("registerRouteLike 메소드는 등록 요청시")
-	class RegisterInvitation {
+	class RegisterRouteLike {
 
 		@Test
 		@DisplayName("사용자가 좋아요를 누르지 않은 루트라면 좋아요를 등록한다.")
@@ -152,6 +154,64 @@ class RouteLikeServiceTest {
 			then(routeLikeRepository)
 					.should()
 					.existsByRouteIdAndMemberId(route.getId(), member.getId());
+		}
+
+	}
+
+	@Nested
+	@DisplayName("deleteRouteLike 메소드는 삭제 요청시")
+	class DeleteRouteLike {
+
+		@Test
+		@DisplayName("사용자가 좋아요를 눌렀던 루트라면 좋아요를 삭제한다.")
+		void success() {
+			//mocking
+			given(memberRepository.findById(member.getId()))
+					.willReturn(Optional.of(member));
+			given(routeRepository.findById(route.getId()))
+					.willReturn(Optional.of(route));
+			given(routeLikeRepository.deleteByRouteIdAndMemberId(route.getId(), member.getId()))
+					.willReturn(1);
+
+			//when
+			routeLikeService.deleteRouteLike(route.getId());
+
+			//then
+			then(memberRepository)
+					.should()
+					.findById(member.getId());
+			then(routeRepository)
+					.should()
+					.findById(route.getId());
+			then(routeLikeRepository)
+					.should()
+					.deleteByRouteIdAndMemberId(route.getId(), member.getId());
+		}
+
+		@Test
+		@DisplayName("사용자가 좋아요를 누르지 않은 상태라면 예외가 발생한다.")
+		void failed() {
+			//mocking
+			given(memberRepository.findById(member.getId()))
+					.willReturn(Optional.of(member));
+			given(routeRepository.findById(route.getId()))
+					.willReturn(Optional.of(route));
+			given(routeLikeRepository.deleteByRouteIdAndMemberId(route.getId(), member.getId()))
+					.willReturn(0);
+
+			//when
+			//then
+			Assertions.assertThrows(EntityNotFoundException.class, () -> routeLikeService.deleteRouteLike(route.getId()));
+
+			then(memberRepository)
+					.should()
+					.findById(member.getId());
+			then(routeRepository)
+					.should()
+					.findById(route.getId());
+			then(routeLikeRepository)
+					.should()
+					.deleteByRouteIdAndMemberId(route.getId(), member.getId());
 		}
 
 	}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- RouteLike 삭제 기능 구현 및 테스트

### ⛏ 중점 사항

- 엔드포인트를 등록과 동일하게 변경했습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-253], [WUMO-254]

[WUMO-253]: https://shoekream.atlassian.net/browse/WUMO-253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-254]: https://shoekream.atlassian.net/browse/WUMO-254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ