### PR TITLE
[WUMO-85] LocationComment 삭제 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
@@ -60,6 +60,8 @@ public class LocationCommentController {
 	public ResponseEntity<Void> deleteLocationComment(
 			@PathVariable("id") @Parameter(description = "삭제하고자 하는 후보지 댓글") Long id
 	) {
+
+		locationCommentService.deleteLocationComment(id);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
@@ -72,11 +72,24 @@ public class LocationCommentService {
 		checkMemberInParty(locationComment.getPartyMember().getId());
 
 		if (!locationComment.getMember().getId().equals(getMemberId())) {
-			throw new AccessDeniedException("댓글은 작성자만 삭제할 수 있습니다.");
+			throw new AccessDeniedException("댓글은 작성자만 수정할 수 있습니다.");
 		}
 		locationComment.update(locationCommentUpdateRequest);
 
 		return toLocationCommentUpdateResponse(locationCommentRepository.save(locationComment));
+	}
+
+	@Transactional
+	public void deleteLocationComment(Long locationCommentId){
+		LocationComment locationComment = getLocationCommentEntity(locationCommentId);
+
+		checkMemberInParty(locationComment.getPartyMember().getId());
+
+		if (!locationComment.getMember().getId().equals(getMemberId())) {
+			throw new AccessDeniedException("댓글은 작성자만 삭제할 수 있습니다.");
+		}
+
+		locationCommentRepository.deleteById(locationCommentId);
 	}
 
 	private LocationComment getLocationCommentEntity(Long locationCommentId) {

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.comment.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -224,7 +225,7 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 	void updateLocationCommentUpdateTest() throws Exception {
 		// Given
 		LocationCommentUpdateRequest request =
-					new LocationCommentUpdateRequest(locationComment.getId(), "다음에는 반얀트리 가야지!!", "image.png");
+				new LocationCommentUpdateRequest(locationComment.getId(), "다음에는 반얀트리 가야지!!", "image.png");
 
 		// When
 		ResultActions resultActions =
@@ -244,5 +245,32 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.image").value("image.png"))
 				.andDo(print());
 
+	}
+
+	@Test
+	@DisplayName(" 후보지 댓글을 삭제할 수 있다.")
+	void deleteLocationComment() throws Exception {
+		// Given
+		LocationComment toBeDeleted = locationCommentRepository.save(
+				LocationComment.builder()
+						.member(member)
+						.image("image.png")
+						.locationId(location.getId())
+						.content("여기 별론데...")
+						.partyMember(partyMember)
+						.isEdited(false)
+						.build()
+		);
+
+		// When
+		ResultActions resultActions =
+				mockMvc.perform(
+						delete("/api/v1/location-comments/{id}", toBeDeleted.getId())
+				);
+
+		// Then
+		resultActions
+				.andExpect(status().isOk())
+				.andDo(print());
 	}
 }


### PR DESCRIPTION
### 📝 작업 요약

후보지 댓글 삭제 기능 구현 및 테스트

### ⛏ 중점 사항

후보지 댓글 삭제 기능입니다.
추후 리팩토링이 필요한 부분이 존재합니다

- getMemerEntity 메소드를 getPartyMemberEntity 의 member 필드를 가져오는 방식으로 대체

### 💡 관련 이슈


- Resolved : WUMO-255, WUMO-256