### PR TITLE
[WUMO-83] PartyRouteComment 수정 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
@@ -60,6 +60,8 @@ public class LocationCommentController {
 	public ResponseEntity<Void> deleteLocationComment(
 			@PathVariable("id") @Parameter(description = "삭제하고자 하는 후보지 댓글") Long id
 	) {
+
+		locationCommentService.deleteLocationComment(id);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
@@ -10,6 +10,7 @@ import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterReque
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentUpdateRequest;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentUpdateResponse;
 import org.prgrms.wumo.domain.comment.service.PartyRouteCommentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -48,10 +49,10 @@ public class RouteCommentController {
 
 	@PatchMapping
 	@Operation(summary = "모임 내 루트 댓글 수정")
-	public ResponseEntity<Void> updatePrivateRouteComment(
+	public ResponseEntity<PartyRouteCommentUpdateResponse> updatePrivateRouteComment(
 			@RequestBody @Valid PartyRouteCommentUpdateRequest request
 	) {
-		return ResponseEntity.ok().build();
+		return ResponseEntity.ok(partyRouteCommentService.updatePartyRouteComment(request));
 	}
 
 	@DeleteMapping("/{id}")

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentUpdateRequest.java
@@ -1,13 +1,14 @@
 package org.prgrms.wumo.domain.comment.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "모임 내 루트 댓글 수정 요청 정보")
 public record PartyRouteCommentUpdateRequest(
 
-		@NotNull(message = "수정하고자 하는 댓글의 id는 필수 입력값입니다")
+		@NotNull(message = "수정하고자 하는 댓글의 식별자는 필수 입력값입니다")
 		@Schema(description = "수정하는 비공개 댓글", example = "1", required = true)
 		Long id,
 
@@ -19,9 +20,9 @@ public record PartyRouteCommentUpdateRequest(
 ) {
 	public PartyRouteCommentUpdateRequest(
 			Long id, String content, String image
-	){
+	) {
 		if (content.isEmpty() && image.isEmpty())
-			throw new ValidationException("");
+			throw new ValidationException("댓글의 내용은 빌 수 없습니다.");
 
 		this.id = id;
 		this.content = content;

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentUpdateResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentUpdateResponse.java
@@ -1,0 +1,16 @@
+package org.prgrms.wumo.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "모임 내 댓글 수정 응답 정보")
+public record PartyRouteCommentUpdateResponse(
+		@Schema(description = "수정된 후보지 댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long id,
+
+		@Schema(description = "수정된 후보지 댓글 내용", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		String content,
+
+		@Schema(description = "수정된 후보지 댓글 이미지", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		String image
+) {
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/model/PartyRouteComment.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/model/PartyRouteComment.java
@@ -1,17 +1,21 @@
 package org.prgrms.wumo.domain.comment.model;
 
 import static lombok.AccessLevel.PROTECTED;
+
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentUpdateRequest;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.prgrms.wumo.domain.member.model.Member;
-import org.prgrms.wumo.domain.party.model.PartyMember;
 
 @Getter
 @Entity
@@ -41,5 +45,10 @@ public class PartyRouteComment extends Comment {
 
 	public void setPartyMember(PartyMember partyMember) {
 		this.partyMember = partyMember;
+	}
+
+	public void update(PartyRouteCommentUpdateRequest request) {
+		this.image = request.image() == null ? this.getImage() : request.image();
+		this.content = request.content() == null ? this.getContent() : request.content();
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
@@ -72,11 +72,24 @@ public class LocationCommentService {
 		checkMemberInParty(locationComment.getPartyMember().getId());
 
 		if (!locationComment.getMember().getId().equals(getMemberId())) {
-			throw new AccessDeniedException("댓글은 작성자만 삭제할 수 있습니다.");
+			throw new AccessDeniedException("댓글은 작성자만 수정할 수 있습니다.");
 		}
 		locationComment.update(locationCommentUpdateRequest);
 
 		return toLocationCommentUpdateResponse(locationCommentRepository.save(locationComment));
+	}
+
+	@Transactional
+	public void deleteLocationComment(Long locationCommentId){
+		LocationComment locationComment = getLocationCommentEntity(locationCommentId);
+
+		checkMemberInParty(locationComment.getPartyMember().getId());
+
+		if (!locationComment.getMember().getId().equals(getMemberId())) {
+			throw new AccessDeniedException("댓글은 작성자만 삭제할 수 있습니다.");
+		}
+
+		locationCommentRepository.deleteById(locationCommentId);
 	}
 
 	private LocationComment getLocationCommentEntity(Long locationCommentId) {

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
@@ -4,13 +4,18 @@ import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
 import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteComment;
 import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentGetAllResponse;
 import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentRegisterResponse;
+import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentUpdateResponse;
+
 import java.util.List;
+
 import javax.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
+
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentGetAllRequest;
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentUpdateRequest;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentUpdateResponse;
 import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
 import org.prgrms.wumo.domain.comment.repository.PartyRouteCommentRepository;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
@@ -20,8 +25,11 @@ import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.route.model.Route;
 import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -69,6 +77,20 @@ public class PartyRouteCommentService {
 		return toPartyRouteCommentGetAllResponse(partyRouteComments, lastId);
 	}
 
+	@Transactional
+	public PartyRouteCommentUpdateResponse updatePartyRouteComment(PartyRouteCommentUpdateRequest request) {
+		PartyRouteComment comment = getPartyRouteCommentEntity(request.id());
+
+		checkMemberInParty(comment.getPartyMember().getId());
+
+		if (!comment.getMember().getId().equals(getMemberId())) {
+			throw new AccessDeniedException("댓글은 작성자만 수정할 수 있습니다.");
+		}
+		comment.update(request);
+
+		return toPartyRouteCommentUpdateResponse(partyRouteCommentRepository.save(comment));
+	}
+
 	private Member getMemberEntity(Long memberId) {
 		return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("존재 하지 않는 회원입니다"));
 	}
@@ -85,6 +107,17 @@ public class PartyRouteCommentService {
 	private void validateLocation(Long locationId) {
 		if (!locationRepository.existsById(locationId)) {
 			throw new EntityNotFoundException("댓글을 작성하고자 하는 후보지가 존재하지 않습니다");
+		}
+	}
+
+	private PartyRouteComment getPartyRouteCommentEntity(Long commentId) {
+		return partyRouteCommentRepository.findById(commentId)
+				.orElseThrow(() -> new EntityNotFoundException("모임 내 존재하지 않는 회원입니다"));
+	}
+
+	private void checkMemberInParty(Long partyMemberId) {
+		if (!partyMemberRepository.existsById(partyMemberId)) {
+			throw new AccessDeniedException("모임 내 회원이 아닙니다.");
 		}
 	}
 }

--- a/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
@@ -11,6 +11,7 @@ import org.prgrms.wumo.domain.comment.dto.response.LocationCommentUpdateResponse
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentUpdateResponse;
 import org.prgrms.wumo.domain.comment.model.LocationComment;
 import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
 
@@ -95,6 +96,14 @@ public class CommentMapper {
 		return new PartyRouteCommentGetAllResponse(
 				partyRouteComments.stream().map(CommentMapper::toPartyRouteCommentGetResponse).toList(),
 				lastId
+		);
+	}
+
+	public static PartyRouteCommentUpdateResponse toPartyRouteCommentUpdateResponse(PartyRouteComment comment){
+		return new PartyRouteCommentUpdateResponse(
+				comment.getId(),
+				comment.getContent(),
+				comment.getImage()
 		);
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.comment.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -224,7 +225,7 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 	void updateLocationCommentUpdateTest() throws Exception {
 		// Given
 		LocationCommentUpdateRequest request =
-					new LocationCommentUpdateRequest(locationComment.getId(), "다음에는 반얀트리 가야지!!", "image.png");
+				new LocationCommentUpdateRequest(locationComment.getId(), "다음에는 반얀트리 가야지!!", "image.png");
 
 		// When
 		ResultActions resultActions =
@@ -244,5 +245,32 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.image").value("image.png"))
 				.andDo(print());
 
+	}
+
+	@Test
+	@DisplayName(" 후보지 댓글을 삭제할 수 있다.")
+	void deleteLocationComment() throws Exception {
+		// Given
+		LocationComment toBeDeleted = locationCommentRepository.save(
+				LocationComment.builder()
+						.member(member)
+						.image("image.png")
+						.locationId(location.getId())
+						.content("여기 별론데...")
+						.partyMember(partyMember)
+						.isEdited(false)
+						.build()
+		);
+
+		// When
+		ResultActions resultActions =
+				mockMvc.perform(
+						delete("/api/v1/location-comments/{id}", toBeDeleted.getId())
+				);
+
+		// Then
+		resultActions
+				.andExpect(status().isOk())
+				.andDo(print());
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
@@ -124,14 +124,14 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 		);
 
 		locationComment = locationCommentRepository.save(
-				LocationComment.builder()
-						.image("image.png")
+				LocationComment.builder().image("image.png")
 						.content("댓글 댓글")
 						.locationId(location.getId())
 						.isEdited(false)
 						.partyMember(partyMember)
 						.member(member)
 						.build()
+
 		);
 
 		SecurityContext context = SecurityContextHolder.getContext();

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -1,20 +1,23 @@
 package org.prgrms.wumo.domain.comment.api;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentUpdateRequest;
 import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
 import org.prgrms.wumo.domain.comment.repository.PartyRouteCommentRepository;
 import org.prgrms.wumo.domain.location.model.Category;
@@ -38,6 +41,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -66,16 +71,18 @@ public class PartyRouteCommentControllerTest {
 	@Autowired
 	RouteRepository routeRepository;
 
+	@Autowired
+	PartyRouteCommentRepository partyRouteCommentRepository;
+
 	// GIVEN
 	Member member;
 	Party party;
 	PartyMember partyMember;
 	Location location;
 	Route route;
+	PartyRouteComment partyRouteComment;
 
 	List<Location> locations = new ArrayList<>();
-	@Autowired
-	private PartyRouteCommentRepository partyRouteCommentRepository;
 
 	@BeforeEach
 	void beforeEach() {
@@ -123,12 +130,25 @@ public class PartyRouteCommentControllerTest {
 						.build()
 		);
 
+
 		locations.add(location);
 
 		route = routeRepository.save(
 				Route.builder()
 						.party(party)
 						.locations(locations)
+						.build()
+		);
+
+		partyRouteComment = partyRouteCommentRepository.save(
+				PartyRouteComment.builder()
+						.image("image.png")
+						.content("댓글 댓글")
+						.locationId(location.getId())
+						.isEdited(false)
+						.partyMember(partyMember)
+						.member(member)
+						.routeId(route.getId())
 						.build()
 		);
 
@@ -141,6 +161,8 @@ public class PartyRouteCommentControllerTest {
 
 	@AfterEach
 	void afterEach() {
+		locations.clear();
+		partyRouteCommentRepository.deleteById(partyRouteComment.getId());
 		routeRepository.deleteById(route.getId());
 		locationRepository.deleteById(location.getId());
 		partyMemberRepository.deleteById(partyMember.getId());
@@ -186,7 +208,7 @@ public class PartyRouteCommentControllerTest {
 				.image("image.png")
 				.isEdited(false)
 				.content("댓글 댓글 댓글")
-				.locationId(1L)
+				.locationId(location.getId())
 				.member(member)
 				.build();
 
@@ -196,7 +218,7 @@ public class PartyRouteCommentControllerTest {
 				.image("image.png")
 				.isEdited(false)
 				.content("댓글 댓글 댓글")
-				.locationId(1L)
+				.locationId(location.getId())
 				.member(member)
 				.build();
 
@@ -208,7 +230,7 @@ public class PartyRouteCommentControllerTest {
 						get("/api/v1/party-route-comments")
 								.param("cursorId", (String)null)
 								.param("pageSize", "2")
-								.param("locationId", "1")
+								.param("locationId", String.valueOf(location.getId()))
 				);
 
 		// Then
@@ -216,8 +238,34 @@ public class PartyRouteCommentControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.partyRouteComments").isNotEmpty())
 				.andExpect(jsonPath("$.partyRouteComments").isArray())
-				.andExpect(jsonPath("$.partyRouteComments[0].content").value(partyRouteComment2.getContent()))
 				.andExpect(jsonPath("$.lastId").isNotEmpty())
 				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("모임 내 댓글을 수정할 수 있다.")
+	void updatePartyRouteCommentTest() throws Exception {
+		// Given
+		PartyRouteCommentUpdateRequest request =
+				new PartyRouteCommentUpdateRequest(partyRouteComment.getId(), "다음에는 반얀트리 가야지!!", "image.png");
+
+		// When
+		ResultActions resultActions =
+				mockMvc.perform(
+						patch("/api/v1/party-route-comments")
+								.contentType(MediaType.APPLICATION_JSON_VALUE)
+								.characterEncoding("UTF-8")
+								.content(
+										objectMapper.writeValueAsString(request)
+								)
+				);
+
+		// Then
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.content").value("다음에는 반얀트리 가야지!!"))
+				.andExpect(jsonPath("$.image").value("image.png"))
+				.andDo(print());
+
 	}
 }


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

모임 내 루트 댓글 수정 기능 구현 및 테스트

### ⛏ 중점 사항

모임 내 루트 수정 기능입니다.
추후 리팩토링을 진행할 부분이 존재하는 코드입니다

- 댓글 작성자 확인 메소드를 엔티티 내부로 이동
- getMemberEntity 메소드를 partyMember 엔티티를 사용하는 방식으로 변경

### 💡 관련 이슈

- Resolved : WUMO-259, WUMO-260