### PR TITLE
[WUMO-86] PartyRouteComment 삭제 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
@@ -64,6 +64,7 @@ public class RouteCommentController {
 	public ResponseEntity<Void> deletePrivateRouteComment(
 			@PathVariable("id") @Parameter(description = "삭제하고자 하는 비공개 루트 댓글") Long id
 	) {
+		partyRouteCommentService.deletePartyRouteComment(id);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
@@ -92,6 +92,19 @@ public class PartyRouteCommentService {
 		return toPartyRouteCommentUpdateResponse(partyRouteCommentRepository.save(partyRouteComment));
 	}
 
+	@Transactional
+	public void deletePartyRouteComment(Long partyRouteCommentId) {
+		PartyRouteComment partyRouteComment = getPartyRouteCommentEntity(partyRouteCommentId);
+
+		checkMemberInParty(partyRouteComment.getPartyMember().getId());
+
+		if (!partyRouteComment.getMember().getId().equals(getMemberId())) {
+			throw new AccessDeniedException("댓글은 작성자만 수정할 수 있습니다.");
+		}
+
+		partyRouteCommentRepository.deleteById(partyRouteCommentId);
+	}
+
 	private Member getMemberEntity(Long memberId) {
 		return memberRepository.findById(memberId).orElseThrow(() -> new EntityNotFoundException("존재 하지 않는 회원입니다"));
 	}

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
@@ -99,7 +99,7 @@ public class PartyRouteCommentService {
 		checkMemberInParty(partyRouteComment.getPartyMember().getId());
 
 		if (!partyRouteComment.getMember().getId().equals(getMemberId())) {
-			throw new AccessDeniedException("댓글은 작성자만 수정할 수 있습니다.");
+			throw new AccessDeniedException("댓글은 작성자만 삭제할 수 있습니다.");
 		}
 
 		partyRouteCommentRepository.deleteById(partyRouteCommentId);

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.domain.comment.api;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -264,6 +265,35 @@ public class PartyRouteCommentControllerTest {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.content").value("다음에는 반얀트리 가야지!!"))
 				.andExpect(jsonPath("$.image").value("image.png"))
+				.andDo(print());
+
+	}
+
+	@Test
+	@DisplayName("모임 내 루트 댓글을 삭제 할 수 있다.")
+	void deletePartyRouteCommentTest() throws Exception {
+		// Given
+		PartyRouteComment toBeDeleted = partyRouteCommentRepository.save(
+				PartyRouteComment.builder()
+						.member(member)
+						.image("image.png")
+						.locationId(location.getId())
+						.content("여기 별론데...")
+						.partyMember(partyMember)
+						.routeId(route.getId())
+						.isEdited(false)
+						.build()
+		);
+
+		// When
+		ResultActions resultActions =
+				mockMvc.perform(
+						delete("/api/v1/party-route-comments/{id}", toBeDeleted.getId())
+				);
+
+		// Then
+		resultActions
+				.andExpect(status().isOk())
 				.andDo(print());
 
 	}

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -288,7 +288,7 @@ public class PartyRouteCommentControllerTest {
 		// When
 		ResultActions resultActions =
 				mockMvc.perform(
-						delete("/api/v1/party-route-comments/{id}", toBeDeleted.getId())
+						delete("/api/v1/party-route-comments/{partyRouteCommentId}", toBeDeleted.getId())
 				);
 
 		// Then


### PR DESCRIPTION
### 📝 작업 요약

모임 내 루트 댓글 삭제 기능 구현 및 테스트

### ⛏ 중점 사항

모임 내 루트 삭제 기능입니다.
추후 리팩토링을 진행할 부분이 존재하는 코드입니다
리팩토링은 본 기능이 반영되면 시작할 예정입니다!

- isEdited 칼럼 삭제
- 댓글 작성자 확인 메소드를 엔티티 내부로 이동
- getMemberEntity 메소드를 partyMember 엔티티를 사용하는 방식으로 변경


### 💡 관련 이슈

- Resolved : WUMO-264, WUMO-265