### PR TITLE
[WUMO-266] Comment API 명세서 보완 및 용어 정리

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
@@ -50,18 +50,18 @@ public class LocationCommentController {
 	@PatchMapping
 	@Operation(summary = "후보지 댓글 수정")
 	public ResponseEntity<LocationCommentUpdateResponse> updateLocationComment(
-			@RequestBody @Valid LocationCommentUpdateRequest request
+			@RequestBody @Valid LocationCommentUpdateRequest locationCommentUpdateRequest
 	) {
-		return ResponseEntity.ok(locationCommentService.updateLocationComment(request));
+		return ResponseEntity.ok(locationCommentService.updateLocationComment(locationCommentUpdateRequest));
 	}
 
 	@DeleteMapping("/{id}")
 	@Operation(summary = "후보지 댓글 삭제")
 	public ResponseEntity<Void> deleteLocationComment(
-			@PathVariable("id") @Parameter(description = "삭제하고자 하는 후보지 댓글") Long id
+			@PathVariable("id") @Parameter(description = "삭제하고자 하는 후보지 댓글 식별자") Long locationCommentId
 	) {
 
-		locationCommentService.deleteLocationComment(id);
+		locationCommentService.deleteLocationComment(locationCommentId);
 		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/RouteCommentController.java
@@ -53,7 +53,7 @@ public class RouteCommentController {
 
 	@PatchMapping
 	@Operation(summary = "모임 내 루트 댓글 수정")
-	public ResponseEntity<PartyRouteCommentUpdateResponse> updatePrivateRouteComment(
+	public ResponseEntity<PartyRouteCommentUpdateResponse> updatePartyRouteComment(
 			@RequestBody @Valid PartyRouteCommentUpdateRequest partyRouteCommentUpdateRequest
 	) {
 		return ResponseEntity.ok(partyRouteCommentService.updatePartyRouteComment(partyRouteCommentUpdateRequest));
@@ -61,10 +61,10 @@ public class RouteCommentController {
 
 	@DeleteMapping("/{id}")
 	@Operation(summary = "모임 내 루트 댓글 삭제")
-	public ResponseEntity<Void> deletePrivateRouteComment(
-			@PathVariable("id") @Parameter(description = "삭제하고자 하는 비공개 루트 댓글") Long id
+	public ResponseEntity<Void> deletePartyRouteComment(
+			@PathVariable("id") @Parameter(description = "삭제하고자 하는 모임 내 루트 댓글 식별자") Long partyRouteCommentId
 	) {
-		partyRouteCommentService.deletePartyRouteComment(id);
+		partyRouteCommentService.deletePartyRouteComment(partyRouteCommentId);
 		return ResponseEntity.ok().build();
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentGetAllRequest.java
@@ -1,8 +1,9 @@
 package org.prgrms.wumo.domain.comment.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "후보지 댓글 전체 조회 요청 정보")
 public record LocationCommentGetAllRequest(
@@ -15,8 +16,8 @@ public record LocationCommentGetAllRequest(
 		@Schema(description = "페이지 사이즈", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
 		int pageSize,
 
-		@NotNull(message = "조회할 후보지 id는 필수 입력값입니다.")
-		@Schema(description = "댓글을 조회할 후보지", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "댓글을 조회할 후보지 식별자는 필수 입력값입니다.")
+		@Schema(description = "댓글을 조회할 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentGetAllRequest.java
@@ -7,16 +7,16 @@ import javax.validation.constraints.Positive;
 @Schema(name = "후보지 댓글 전체 조회 요청 정보")
 public record LocationCommentGetAllRequest(
 
-		@Schema(description = "커서 아이디", example = "0", required = false)
+		@Schema(description = "커서 식별자", example = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		Long cursorId,
 
 		@NotNull(message = "페이지 사이즈는 필수 입력값입니다.")
 		@Positive(message = "페이지 사이즈는 양수여야합니다.")
-		@Schema(description = "페이지 사이즈", example = "5", required = true)
+		@Schema(description = "페이지 사이즈", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
 		int pageSize,
 
 		@NotNull(message = "조회할 후보지 id는 필수 입력값입니다.")
-		@Schema(description = "댓글을 조회할 후보지", example = "1", required = true)
+		@Schema(description = "댓글을 조회할 후보지", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentRegisterRequest.java
@@ -7,18 +7,18 @@ import javax.validation.constraints.NotNull;
 @Schema(name = "후보지 댓글 생성 요청 정보")
 public record LocationCommentRegisterRequest(
 
-		@Schema(description = "댓글 내용", example = "댓글 내용", required = false)
+		@Schema(description = "댓글 내용", example = "댓글 내용", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 첨부 사진 주소", example = "http://", required = false)
+		@Schema(description = "댓글 이미지 주소", example = "http://", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
 		@NotNull(message = "댓글을 다는 후보지의 정보는 필수 입력값입니다.")
-		@Schema(description = "댓글이 작성된 후보지 id", example = "1", required = true)
+		@Schema(description = "댓글이 작성된 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId,
 
 		@NotNull(message = "댓글을 다는 모임에서의 역할 id 는 필수 입력값입니다.")
-		@Schema(description = "댓글의 모임 역할 식별자", example = "1", required = true)
+		@Schema(description = "댓글의 모임 역할 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long partyMemberId
 
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentRegisterRequest.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.comment.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 
@@ -10,22 +11,21 @@ public record LocationCommentRegisterRequest(
 		@Schema(description = "댓글 내용", example = "댓글 내용", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 이미지 주소", example = "http://", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
-		@NotNull(message = "댓글을 다는 후보지의 정보는 필수 입력값입니다.")
+		@NotNull(message = "댓글을 다는 후보지의 식별자는 필수 입력값입니다.")
 		@Schema(description = "댓글이 작성된 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId,
 
-		@NotNull(message = "댓글을 다는 모임에서의 역할 id 는 필수 입력값입니다.")
+		@NotNull(message = "댓글을 다는 모임에서의 역할 식별자는 필수 입력값입니다.")
 		@Schema(description = "댓글의 모임 역할 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long partyMemberId
-
 
 ) {
 	public LocationCommentRegisterRequest(
 			String content, String image, Long locationId, Long partyMemberId
-	){
+	) {
 		if (content.isEmpty() && image.isEmpty())
 			throw new ValidationException("내용이 빌 수는 없습니다");
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentUpdateRequest.java
@@ -15,14 +15,14 @@ public record LocationCommentUpdateRequest(
 		@Schema(description = "수정된 댓글 내용", example = "변경된 내용", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
-		@Schema(description = "수정된 댓글 이미지", example = "http://", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "수정된 댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image
 ) {
 	public LocationCommentUpdateRequest(
 			Long id, String content, String image
 	) {
 		if (content.isEmpty() && image.isEmpty())
-			throw new ValidationException("");
+			throw new ValidationException("내용이 빌 수는 없습니다.");
 
 		this.id = id;
 		this.content = content;

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentUpdateRequest.java
@@ -8,14 +8,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "후보지 댓글 수정 요청 정보")
 public record LocationCommentUpdateRequest(
 
-		@NotNull(message = "수정하고자 하는 댓글의 id는 필수 입력값입니다")
-		@Schema(description = "수정하는 후보지 댓글 식별자", example = "1", required = true)
+		@NotNull(message = "수정하고자 하는 댓글의 식별자는 필수 입력값입니다")
+		@Schema(description = "수정하는 후보지 댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
-		@Schema(description = "댓글 수정 내용", example = "변경된 내용", required = true)
+		@Schema(description = "수정된 댓글 내용", example = "변경된 내용", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 이미지 수정", example = "http://", required = true)
+		@Schema(description = "수정된 댓글 이미지", example = "http://", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image
 ) {
 	public LocationCommentUpdateRequest(

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentGetAllRequest.java
@@ -7,16 +7,16 @@ import javax.validation.constraints.Positive;
 @Schema(name = "모임 내 루트 댓글 전체 조회 요청 정보")
 public record PartyRouteCommentGetAllRequest(
 
-		@Schema(description = "커서 아이디", example = "0", required = false)
+		@Schema(description = "커서 아이디", example = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		Long cursorId,
 
 		@NotNull(message = "페이지 사이즈는 필수 입력값입니다.")
 		@Positive(message = "페이지 사이즈는 양수여야합니다.")
-		@Schema(description = "페이지 사이즈", example = "5", required = true)
+		@Schema(description = "페이지 사이즈", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
 		int pageSize,
 
 		@NotNull(message = "모임 내 일정에서 댓글을 조회할 후보지의 식별자는 필수 입력값입니다.")
-		@Schema(description = "댓글을 조회할 모임 내 루트에서의 후보지 식별자", example = "1", required = true)
+		@Schema(description = "댓글을 조회할 모임 내 루트에서의 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentGetAllRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentGetAllRequest.java
@@ -7,7 +7,7 @@ import javax.validation.constraints.Positive;
 @Schema(name = "모임 내 루트 댓글 전체 조회 요청 정보")
 public record PartyRouteCommentGetAllRequest(
 
-		@Schema(description = "커서 아이디", example = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "커서 식별자", example = "0", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		Long cursorId,
 
 		@NotNull(message = "페이지 사이즈는 필수 입력값입니다.")
@@ -15,7 +15,7 @@ public record PartyRouteCommentGetAllRequest(
 		@Schema(description = "페이지 사이즈", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
 		int pageSize,
 
-		@NotNull(message = "모임 내 일정에서 댓글을 조회할 후보지의 식별자는 필수 입력값입니다.")
+		@NotNull(message = "댓글을 조회할 모임 내 일정에서 댓글을 조회할 후보지의 식별자는 필수 입력값입니다.")
 		@Schema(description = "댓글을 조회할 모임 내 루트에서의 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
@@ -4,25 +4,25 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.ValidationException;
 import javax.validation.constraints.NotNull;
 
-@Schema(name = "모임 내 일정 댓글 생성 요청")
+@Schema(name = "모임 내 루트 댓글 생성 요청")
 public record PartyRouteCommentRegisterRequest(
 
-		@NotNull(message = "댓글 성성 요청자의 id는 필수 입력값입니다")
-		@Schema(description = "댓글 생성 요청자 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "댓글 성성 요청자의 식별자는 필수 입력값입니다")
+		@Schema(description = "댓글 생성 요청자 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long memberId,
 
 		@Schema(description = "댓글 내용", example = "댓글", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 사진 링크", example = "http://", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image,
 
-		@NotNull(message = "댓글이 쓰여지는 일정의 id는 필수 입력값입니다.")
-		@Schema(description = "루트 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "댓글이 쓰여지는 일정의 식별자는 필수 입력값입니다.")
+		@Schema(description = "루트 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long routeId,
 
-		@NotNull(message = "댓글이 쓰여지는 일정에서의 장소 id는 필수 입력값입니다. ")
-		@Schema(description = "후보지 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@NotNull(message = "댓글이 쓰여지는 후보지의 식별자는 필수 입력값입니다. ")
+		@Schema(description = "후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {
 	public PartyRouteCommentRegisterRequest(

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
@@ -8,21 +8,21 @@ import javax.validation.constraints.NotNull;
 public record PartyRouteCommentRegisterRequest(
 
 		@NotNull(message = "댓글 성성 요청자의 id는 필수 입력값입니다")
-		@Schema(description = "댓글 생성 요청자 id", example = "1", required = true)
+		@Schema(description = "댓글 생성 요청자 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long memberId,
 
-		@Schema(description = "댓글 내용", example = "댓글", required = true)
+		@Schema(description = "댓글 내용", example = "댓글", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 사진 링크", example = "http://", required = true)
+		@Schema(description = "댓글 사진 링크", example = "http://", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image,
 
 		@NotNull(message = "댓글이 쓰여지는 일정의 id는 필수 입력값입니다.")
-		@Schema(description = "루트 id", example = "1", required = true)
+		@Schema(description = "루트 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long routeId,
 
 		@NotNull(message = "댓글이 쓰여지는 일정에서의 장소 id는 필수 입력값입니다. ")
-		@Schema(description = "", example = "1", required = true)
+		@Schema(description = "후보지 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {
 	public PartyRouteCommentRegisterRequest(

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentUpdateRequest.java
@@ -8,13 +8,13 @@ import javax.validation.constraints.NotNull;
 public record PartyRouteCommentUpdateRequest(
 
 		@NotNull(message = "수정하고자 하는 댓글의 식별자는 필수 입력값입니다")
-		@Schema(description = "수정하는 비공개 댓글", example = "1", required = true)
+		@Schema(description = "수정하는 비공개 댓글", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
-		@Schema(description = "댓글 내용", example = "변경된 내용", required = true)
+		@Schema(description = "댓글 내용", example = "변경된 내용", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 이미지 url", example = "http://", required = true)
+		@Schema(description = "댓글 이미지 url", example = "http://", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image
 ) {
 	public PartyRouteCommentUpdateRequest(

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentUpdateRequest.java
@@ -8,20 +8,20 @@ import javax.validation.constraints.NotNull;
 public record PartyRouteCommentUpdateRequest(
 
 		@NotNull(message = "수정하고자 하는 댓글의 식별자는 필수 입력값입니다")
-		@Schema(description = "수정하는 비공개 댓글", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "모임 내 루트 댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
-		@Schema(description = "댓글 내용", example = "변경된 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "수정된 댓글 내용", example = "수정된 내용", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 이미지 url", example = "http://", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "수정된 댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image
 ) {
 	public PartyRouteCommentUpdateRequest(
 			Long id, String content, String image
 	){
 		if (content.isEmpty() && image.isEmpty())
-			throw new ValidationException("");
+			throw new ValidationException("내용이 빌 수는 없습니다.");
 
 		this.id = id;
 		this.content = content;

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetAllResponse.java
@@ -9,7 +9,7 @@ public record LocationCommentGetAllResponse(
 		@Schema(description = "후보지 댓글 목록 정보")
 		List<LocationCommentGetResponse> locationComments,
 
-		@Schema(description = "커서 아이디", example = "10", required = true)
+		@Schema(description = "커서 아이디", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long lastId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetAllResponse.java
@@ -3,13 +3,13 @@ package org.prgrms.wumo.domain.comment.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 
-@Schema(name = "특정 후보지 내의 전체 댓글 응답 정보")
+@Schema(name = "후보지 댓글 전체 조회 응답 정보")
 public record LocationCommentGetAllResponse(
 
 		@Schema(description = "후보지 댓글 목록 정보")
 		List<LocationCommentGetResponse> locationComments,
 
-		@Schema(description = "커서 아이디", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "커서 식별자", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long lastId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
@@ -6,28 +6,28 @@ import java.time.LocalDateTime;
 @Schema(name = "후보지 댓글 상세 응답 정보")
 public record LocationCommentGetResponse(
 
-		@Schema(description = "댓글 id")
+		@Schema(description = "댓글 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
-		@Schema(description = "댓글 등록인 닉네임")
+		@Schema(description = "댓글 등록인 닉네임", example = "보섭", requiredMode = Schema.RequiredMode.REQUIRED)
 		String nickName,
 
-		@Schema(description = "댓글 등록인 프로필 사진")
+		@Schema(description = "댓글 등록인 프로필 사진", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String profileImage,
 
-		@Schema(description = "댓글 등록인 역할")
+		@Schema(description = "댓글 등록인 역할", example = "총무", requiredMode = Schema.RequiredMode.REQUIRED)
 		String memberRole,
 
-		@Schema(description = "댓글 내용")
+		@Schema(description = "댓글 내용", example = "이거 먹으러 가자!", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 첨부 이미지")
+		@Schema(description = "댓글 첨부 이미지", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
-		@Schema(description = "댓글 등록 시간")
+		@Schema(description = "댓글 등록 시간", example = "2023-03-03T13:03:23", requiredMode = Schema.RequiredMode.REQUIRED)
 		LocalDateTime createdAt,
 
-		@Schema(description = "댓글 수정 시간")
+		@Schema(description = "댓글 수정 시간", example = "2023-03-03T14:03:23", requiredMode = Schema.RequiredMode.REQUIRED)
 		LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 @Schema(name = "후보지 댓글 상세 응답 정보")
 public record LocationCommentGetResponse(
 
-		@Schema(description = "댓글 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
 		@Schema(description = "댓글 등록인 닉네임", example = "보섭", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -21,7 +21,7 @@ public record LocationCommentGetResponse(
 		@Schema(description = "댓글 내용", example = "이거 먹으러 가자!", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 첨부 이미지", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "댓글 첨부 이미지 주소", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
 		@Schema(description = "댓글 등록 시간", example = "2023-03-03T13:03:23", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
@@ -21,7 +21,7 @@ public record LocationCommentGetResponse(
 		@Schema(description = "댓글 내용", example = "이거 먹으러 가자!", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 첨부 이미지 주소", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "댓글 이미지 주소", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
 		@Schema(description = "댓글 등록 시간", example = "2023-03-03T13:03:23", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentRegisterResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentRegisterResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "후보지 댓글 생성 응답 정보")
 public record LocationCommentRegisterResponse (
 
-		@Schema(description = "생성된 후보지 댓글 id")
+		@Schema(description = "생성된 후보지 댓글 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id
 ){
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentRegisterResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentRegisterResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "후보지 댓글 생성 응답 정보")
 public record LocationCommentRegisterResponse (
 
-		@Schema(description = "생성된 후보지 댓글 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "생성된 후보지 댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id
 ){
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentUpdateResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentUpdateResponse.java
@@ -11,7 +11,7 @@ public record LocationCommentUpdateResponse(
 		@Schema(description = "수정된 후보지 댓글 내용", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "수정된 후보지 댓글 이미지", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "수정된 후보지 댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetAllResponse.java
@@ -8,7 +8,7 @@ public record PartyRouteCommentGetAllResponse(
 		@Schema(description = "모임 내 루트 댓글 목록 정보")
 		List<PartyRouteCommentGetResponse> partyRouteComments,
 
-		@Schema(description = "커서 아이디", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "커서 식별자", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 		long lastId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetAllResponse.java
@@ -8,7 +8,7 @@ public record PartyRouteCommentGetAllResponse(
 		@Schema(description = "모임 내 루트 댓글 목록 정보")
 		List<PartyRouteCommentGetResponse> partyRouteComments,
 
-		@Schema(description = "커서 아이디", example = "10", required = true)
+		@Schema(description = "커서 아이디", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 		long lastId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 @Schema(name = "모임 내 루트 댓글 응답 정보")
 public record PartyRouteCommentGetResponse(
 
-		@Schema(description = "댓글 id", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "댓글 식별자", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
 		@Schema(description = "댓글 등록인 닉네임", example = "보섭", requiredMode = Schema.RequiredMode.REQUIRED)
@@ -21,7 +21,7 @@ public record PartyRouteCommentGetResponse(
 		@Schema(description = "댓글 내용", example = "이거 먹으러 가자!", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 첨부 사진", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "댓글 이미지 주소", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
 		@Schema(description = "댓글 등록 시간", example = "2023-03-03T13:03:23", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
@@ -15,7 +15,7 @@ public record PartyRouteCommentGetResponse(
 		@Schema(description = "댓글 등록인 프로필 사진", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String profileImage,
 
-		@Schema(description = "후보지 댓글 등록인 역할", example = "총무", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "댓글 등록인 역할", example = "총무", requiredMode = Schema.RequiredMode.REQUIRED)
 		String memberRole,
 
 		@Schema(description = "댓글 내용", example = "이거 먹으러 가자!", requiredMode = Schema.RequiredMode.NOT_REQUIRED)

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
@@ -6,28 +6,28 @@ import java.time.LocalDateTime;
 @Schema(name = "모임 내 루트 댓글 응답 정보")
 public record PartyRouteCommentGetResponse(
 
-		@Schema(description = "댓글 id")
+		@Schema(description = "댓글 id", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id,
 
-		@Schema(description = "댓글 등록인 닉네임")
+		@Schema(description = "댓글 등록인 닉네임", example = "보섭", requiredMode = Schema.RequiredMode.REQUIRED)
 		String nickName,
 
-		@Schema(description = "댓글 등록인 프로필 사진")
+		@Schema(description = "댓글 등록인 프로필 사진", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String profileImage,
 
-		@Schema(description = "후보지 댓글 등록인 역할")
+		@Schema(description = "후보지 댓글 등록인 역할", example = "총무", requiredMode = Schema.RequiredMode.REQUIRED)
 		String memberRole,
 
-		@Schema(description = "댓글 내용")
+		@Schema(description = "댓글 내용", example = "이거 먹으러 가자!", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "댓글 첨부 사진")
+		@Schema(description = "댓글 첨부 사진", example = "http://~.jpeg", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image,
 
-		@Schema(description = "댓글 등록 시간")
+		@Schema(description = "댓글 등록 시간", example = "2023-03-03T13:03:23", requiredMode = Schema.RequiredMode.REQUIRED)
 		LocalDateTime createdAt,
 
-		@Schema(description = "댓글 수정 시간")
+		@Schema(description = "댓글 수정 시간", example = "2023-03-03T14:03:23", requiredMode = Schema.RequiredMode.REQUIRED)
 		LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentRegisterResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentRegisterResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "모임 내 루트 댓글 생성 응답 정보")
 public record PartyRouteCommentRegisterResponse(
 
-		@Schema(description = "비공개 루트에 작성된 댓글 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "모임 내 루트에 작성된 댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentRegisterResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentRegisterResponse.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "모임 내 루트 댓글 생성 응답 정보")
 public record PartyRouteCommentRegisterResponse(
 
-		@Schema(description = "비공개 루트에 작성된 댓글 id")
+		@Schema(description = "비공개 루트에 작성된 댓글 id", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long id
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentUpdateResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentUpdateResponse.java
@@ -10,7 +10,7 @@ public record PartyRouteCommentUpdateResponse(
 		@Schema(description = "수정된 후보지 댓글 내용", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String content,
 
-		@Schema(description = "수정된 후보지 댓글 이미지", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "수정된 후보지 댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String image
 ) {
 }


### PR DESCRIPTION
### 📝 작업 요약

댓글 API 명세서 정리

### ⛏ 중점 사항

- Swagger required -> requiredMode 로 변경
- 용어 통일
 - 아이디, id -> 식별자 정리
 - 후보 장소 -> 후보지로 통일
- 비어 있는 에러 메세지 채우기

### 💡 관련 이슈

- Resolved : WUMO-267, WUMO-268