### PR TITLE
[WUMO-274] Party 조회 기준 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyGetRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyGetRequest.java
@@ -8,11 +8,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "모임 목록 조회 요청 정보")
 public record PartyGetRequest(
 
+		@NotNull(message = "조회 옵션은 필수 입력 사항입니다.")
+		@Schema(description = "조회 옵션(ONGOING, COMPLETED, ALL)", example = "ONGOING", requiredMode = Schema.RequiredMode.REQUIRED)
+		PartyType partyType,
+
 		@Schema(description = "커서 식별자", example = "5", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		Long cursorId,
 
-		@NotNull
-		@Positive(message = "page size는 0 또는 음수일 수 없습니다.")
+		@NotNull(message = "Page Size는 필수 입력사항입니다.")
+		@Positive(message = "Page Size는 0 또는 음수일 수 없습니다.")
 		@Schema(description = "페이지 사이즈", example = "5", requiredMode = Schema.RequiredMode.REQUIRED)
 		int pageSize
 

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyType.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyType.java
@@ -1,0 +1,27 @@
+package org.prgrms.wumo.domain.party.dto.request;
+
+import java.util.Arrays;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public enum PartyType {
+
+	ONGOING("ONGOING"),
+	COMPLETED("COMPLETED"),
+	ALL("ALL");
+
+	private final String value;
+
+	PartyType(String value) {
+		this.value = value;
+	}
+
+	@JsonCreator
+	public static PartyType from(String value) {
+		return Arrays.stream(PartyType.values())
+				.filter(partyType -> partyType.value.equals(value))
+				.findFirst()
+				.orElse(null);
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/party/model/Party.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/model/Party.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.party.model;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -49,7 +50,7 @@ public class Party extends BaseTimeEntity {
 	public Party(Long id, String name, LocalDateTime startDate, LocalDateTime endDate, String description,
 			String coverImage,
 			String password) {
-		Assert.isTrue(startDate.isBefore(endDate), "종료일이 시작일보다 빠를 수 없습니다.");
+		Assert.isTrue(startDate.isBefore(endDate) || startDate.isEqual(endDate), "종료일이 시작일보다 빠를 수 없습니다.");
 
 		this.id = id;
 		this.name = name;
@@ -62,18 +63,18 @@ public class Party extends BaseTimeEntity {
 
 	public void update(String name, LocalDateTime startDate, LocalDateTime endDate, String description, String coverImage,
 			String password) {
-		if (name != null) this.name = name;
+		this.name = Objects.requireNonNullElse(name, this.name);
 		if (startDate != null) {
-			Assert.isTrue(startDate.isBefore(endDate), "종료일이 시작일보다 빠를 수 없습니다.");
+			Assert.isTrue(startDate.isBefore(endDate) || startDate.isEqual(endDate), "종료일이 시작일보다 빠를 수 없습니다.");
 			this.startDate = startDate;
 		}
 		if (endDate != null) {
-			Assert.isTrue(endDate.isAfter(this.startDate), "시작일이 종료일보다 느릴 수 없습니다.");
+			Assert.isTrue(endDate.isAfter(this.startDate) || endDate.isEqual(this.startDate), "시작일이 종료일보다 느릴 수 없습니다.");
 			this.endDate = endDate;
 		}
-		if (description != null) this.description = description;
-		if (coverImage != null) this.coverImage = coverImage;
-		if (password != null) this.password = password;
+		this.description = Objects.requireNonNullElse(description, this.description);
+		this.coverImage = Objects.requireNonNullElse(coverImage, this.coverImage);
+		this.password = Objects.requireNonNullElse(password, this.password);
 	}
 
 	// TODO : 입장 시 비밀번호 체크 로직

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepository.java
@@ -3,6 +3,7 @@ package org.prgrms.wumo.domain.party.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.prgrms.wumo.domain.party.dto.request.PartyType;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 
 public interface PartyMemberCustomRepository {
@@ -13,7 +14,7 @@ public interface PartyMemberCustomRepository {
 
 	List<PartyMember> findAllByPartyId(Long partyId, Long cursorId, int pageSize);
 
-	List<PartyMember> findAllByMemberId(Long memberId, Long cursorId, int pageSize);
+	List<PartyMember> findAllByMemberId(Long memberId, Long cursorId, int pageSize, PartyType partyType);
 
 	boolean existsByPartyIdAndMemberId(Long partyId, Long memberId);
 

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -61,7 +61,12 @@ public class PartyService {
 
 	@Transactional(readOnly = true)
 	public PartyGetAllResponse getAllParty(PartyGetRequest partyGetRequest) {
-		List<PartyMember> partyMembers = partyMemberRepository.findAllByMemberId(JwtUtil.getMemberId(), partyGetRequest.cursorId(), partyGetRequest.pageSize());
+		List<PartyMember> partyMembers = partyMemberRepository.findAllByMemberId(
+				JwtUtil.getMemberId(),
+				partyGetRequest.cursorId(),
+				partyGetRequest.pageSize(),
+				partyGetRequest.partyType()
+		);
 
 		long lastId = (partyMembers.size() > 0) ? partyMembers.get(partyMembers.size()-1).getId() : -1L;
 

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -105,6 +105,7 @@ class PartyControllerTest extends MysqlTestContainer {
 
 		//when
 		ResultActions resultActions = mockMvc.perform(get("/api/v1/parties/members/me")
+				.param("partyType", "ALL")
 				.param("cursorId", (String)null)
 				.param("pageSize", "5"));
 
@@ -135,8 +136,8 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.id").value(partyRegisterResponse.id()))
 				.andExpect(jsonPath("$.name").value(partyRegisterRequest.name()))
-				.andExpect(jsonPath("$.startDate").isNotEmpty())	// 소수점 표기 기준이 달라 값이 있는지만 검증
-				.andExpect(jsonPath("$.endDate").isNotEmpty())		// 위와 동일
+				.andExpect(jsonPath("$.startDate").isNotEmpty())  // 소수점 표기 기준이 달라 값이 있는지만 검증
+				.andExpect(jsonPath("$.endDate").isNotEmpty())    // 위와 동일
 				.andExpect(jsonPath("$.description").value(partyRegisterRequest.description()))
 				.andExpect(jsonPath("$.coverImage").value(partyRegisterRequest.coverImage()))
 				.andDo(print());

--- a/src/test/java/org/prgrms/wumo/domain/party/model/PartyTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/model/PartyTest.java
@@ -23,8 +23,12 @@ class PartyTest {
 	@DisplayName("수정할 때 모임 시작일보다 모임 종료일이 빠르면 예외가 발생한다.")
 	void checkEndDateIsBeforeStartDateOnUpdate() {
 		Party party = Party.builder()
+				.name("오예스 워크샵")
 				.startDate(LocalDateTime.now())
 				.endDate(LocalDateTime.now().plusDays(1))
+				.description("팀 설립 기념 워크샵")
+				.coverImage("https://~.jpeg")
+				.password("1234")
 				.build();
 
 		assertThrows(IllegalArgumentException.class, () -> party.update(

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -28,6 +28,7 @@ import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyGetRequest;
 import org.prgrms.wumo.domain.party.dto.request.PartyRegisterRequest;
+import org.prgrms.wumo.domain.party.dto.request.PartyType;
 import org.prgrms.wumo.domain.party.dto.request.PartyUpdateRequest;
 import org.prgrms.wumo.domain.party.dto.response.PartyGetAllResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyGetResponse;
@@ -165,29 +166,29 @@ class PartyServiceTest {
 		@DisplayName("사용자가 속한 모임 목록을 반환한다.")
 		void success() {
 			//mocking
-			given(partyMemberRepository.findAllByMemberId(member.getId(), null, 1))
+			given(partyMemberRepository.findAllByMemberId(member.getId(), null, 1, PartyType.ALL))
 					.willReturn(List.of(partyMember));
 
 			//when
-			PartyGetAllResponse partyGetAllResponse = partyService.getAllParty(new PartyGetRequest(null, 1));
+			PartyGetAllResponse partyGetAllResponse = partyService.getAllParty(new PartyGetRequest(PartyType.ALL, null, 1));
 
 			//then
 			assertThat(partyGetAllResponse.party()).isNotEmpty();
 
 			then(partyMemberRepository)
 					.should()
-					.findAllByMemberId(member.getId(), null, 1);
+					.findAllByMemberId(member.getId(), null, 1, PartyType.ALL);
 		}
 
 		@Test
 		@DisplayName("사용자가 속한 모임이 없다면 빈 목록을 반환한다.")
 		void empty() {
 			//mocking
-			given(partyMemberRepository.findAllByMemberId(member.getId(), null, 1))
+			given(partyMemberRepository.findAllByMemberId(member.getId(), null, 1, PartyType.ALL))
 					.willReturn(Collections.emptyList());
 
 			//when
-			PartyGetAllResponse partyGetAllResponse = partyService.getAllParty(new PartyGetRequest(null, 1));
+			PartyGetAllResponse partyGetAllResponse = partyService.getAllParty(new PartyGetRequest(PartyType.ALL, null, 1));
 
 			//then
 			assertThat(partyGetAllResponse.party()).isEmpty();
@@ -195,7 +196,7 @@ class PartyServiceTest {
 
 			then(partyMemberRepository)
 					.should()
-					.findAllByMemberId(member.getId(), null, 1);
+					.findAllByMemberId(member.getId(), null, 1, PartyType.ALL);
 		}
 
 	}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Party 조회 기준 기능 구현 및 테스트

### ⛏ 중점 사항

- 조회 기준은 요구사항에 맞춰 3가지 ENUM으로 정의했습니다.
- 결과값의 정렬 기준은 최신순이고 나중에 등록한 모임 기준으로 상위에 조회됩니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-276], [WUMO-277]

[WUMO-276]: https://shoekream.atlassian.net/browse/WUMO-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-277]: https://shoekream.atlassian.net/browse/WUMO-277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ