### PR TITLE
[WUMO-273] Party 조회시 구성원 및 전체 멤버 수 포함 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyGetRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyGetRequest.java
@@ -8,7 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 @Schema(name = "모임 목록 조회 요청 정보")
 public record PartyGetRequest(
 
-		@NotNull(message = "조회 옵션은 필수 입력 사항입니다.")
+		@NotNull(message = "조회 옵션은 필수 입력사항입니다.")
 		@Schema(description = "조회 옵션(ONGOING, COMPLETED, ALL)", example = "ONGOING", requiredMode = Schema.RequiredMode.REQUIRED)
 		PartyType partyType,
 

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyUpdateRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyUpdateRequest.java
@@ -20,7 +20,7 @@ public record PartyUpdateRequest(
 		LocalDate endDate,
 
 		@Length(max = 255, message = "모임 설명은 {max}자를 초과할 수 없습니다.")
-		@Schema(description = "종료일", example = "팀 설립 기념 워크샵", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+		@Schema(description = "모임 설명", example = "팀 설립 기념 워크샵", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String description,
 
 		@Length(max = 255, message = "이미지 경로는 {max}자를 초과할 수 없습니다.")

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetAllResponse.java
@@ -6,10 +6,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "모임 목록 정보")
 public record PartyGetAllResponse(
+
 		@Schema(description = "모임 목록", requiredMode = Schema.RequiredMode.REQUIRED)
 		List<PartyGetResponse> party,
 
-		@Schema(description = "커서 아이디", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "커서 식별자", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long lastId
+
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyGetResponse.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.party.dto.response;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -23,7 +24,13 @@ public record PartyGetResponse(
 		String description,
 
 		@Schema(description = "이미지 경로", example = "https://~.jpeg", requiredMode = Schema.RequiredMode.REQUIRED)
-		String coverImage
+		String coverImage,
+
+		@Schema(description = "전체 모임 구성원 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long totalMembers,
+
+		@Schema(description = "모임 구성원 목록 (최대 3명)", requiredMode = Schema.RequiredMode.REQUIRED)
+		List<PartyMemberGetResponse> members
 
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyMemberGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyMemberGetAllResponse.java
@@ -6,10 +6,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "모임 구성원 정보 목록")
 public record PartyMemberGetAllResponse(
-		@Schema(description = "모임 구성원 목록")
+
+		@Schema(description = "전체 모임 구성원 수", example = "3", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long totalMembers,
+
+		@Schema(description = "모임 구성원 목록", requiredMode = Schema.RequiredMode.REQUIRED)
 		List<PartyMemberGetResponse> members,
 
-		@Schema(description = "커서 아이디", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Schema(description = "커서 식별자", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long lastId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/model/Party.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/model/Party.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.party.model;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 
 import javax.persistence.Column;
@@ -9,6 +10,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import org.prgrms.wumo.global.audit.BaseTimeEntity;
 import org.springframework.util.Assert;
@@ -46,6 +48,12 @@ public class Party extends BaseTimeEntity {
 	@Column(name = "password", nullable = true, unique = false, length = 4)
 	private String password;
 
+	@Transient
+	private long totalMembers;
+
+	@Transient
+	private List<PartyMember> partyMembers;
+
 	@Builder
 	public Party(Long id, String name, LocalDateTime startDate, LocalDateTime endDate, String description,
 			String coverImage,
@@ -75,6 +83,14 @@ public class Party extends BaseTimeEntity {
 		this.description = Objects.requireNonNullElse(description, this.description);
 		this.coverImage = Objects.requireNonNullElse(coverImage, this.coverImage);
 		this.password = Objects.requireNonNullElse(password, this.password);
+	}
+
+	public void setTotalMembers(long totalMembers) {
+		this.totalMembers = totalMembers;
+	}
+
+	public void setPartyMembers(List<PartyMember> partyMembers) {
+		this.partyMembers = partyMembers;
 	}
 
 	// TODO : 입장 시 비밀번호 체크 로직

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long>, PartyMemberCustomRepository {
 
+	long countAllByParty(Party party);
+
 	@Modifying(clearAutomatically = true)
 	@Query("DELETE FROM PartyMember pm WHERE pm.party = :party")
 	void deleteAllByParty(Party party);

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
@@ -61,14 +61,16 @@ public class PartyMemberService {
 
 	@Transactional(readOnly = true)
 	public PartyMemberGetAllResponse getAllPartyMembers(Long partyId, PartyMemberGetRequest partyMemberGetRequest) {
-		getPartyMemberEntity(partyId, JwtUtil.getMemberId());
+		PartyMember partyMember = getPartyMemberEntity(partyId, JwtUtil.getMemberId());
+
+		long totalMembers = partyMemberRepository.countAllByParty(partyMember.getParty());
 
 		List<PartyMember> partyMembers =
 				partyMemberRepository.findAllByPartyId(partyId, partyMemberGetRequest.cursorId(), partyMemberGetRequest.pageSize());
 
 		long lastId = (partyMembers.size() > 0) ? partyMembers.get(partyMembers.size()-1).getId() : -1L;
 
-		return toPartyMemberGetAllResponse(partyMembers, lastId);
+		return toPartyMemberGetAllResponse(totalMembers, partyMembers, lastId);
 	}
 
 	@Transactional

--- a/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
@@ -47,7 +47,12 @@ public class PartyMapper {
 						LocalDate.from(party.getStartDate()),
 						LocalDate.from(party.getEndDate()),
 						party.getDescription(),
-						party.getCoverImage()))
+						party.getCoverImage(),
+						party.getTotalMembers(),
+						party.getPartyMembers().stream()
+								.map(PartyMapper::toPartyMemberGetResponse)
+								.toList())
+				)
 				.toList();
 		return new PartyGetAllResponse(partyGetResponses, lastId);
 	}
@@ -59,7 +64,11 @@ public class PartyMapper {
 				LocalDate.from(party.getStartDate()),
 				LocalDate.from(party.getEndDate()),
 				party.getDescription(),
-				party.getCoverImage()
+				party.getCoverImage(),
+				party.getTotalMembers(),
+				party.getPartyMembers().stream()
+						.map(PartyMapper::toPartyMemberGetResponse)
+						.toList()
 		);
 	}
 
@@ -72,11 +81,11 @@ public class PartyMapper {
 				.build();
 	}
 
-	public static PartyMemberGetAllResponse toPartyMemberGetAllResponse(List<PartyMember> partyMembers, Long lastId) {
+	public static PartyMemberGetAllResponse toPartyMemberGetAllResponse(Long totalMembers, List<PartyMember> partyMembers, Long lastId) {
 		List<PartyMemberGetResponse> partyMemberGetResponses = partyMembers.stream()
 				.map(PartyMapper::toPartyMemberGetResponse)
 				.toList();
-		return new PartyMemberGetAllResponse(partyMemberGetResponses, lastId);
+		return new PartyMemberGetAllResponse(totalMembers, partyMemberGetResponses, lastId);
 	}
 
 	public static PartyMemberGetResponse toPartyMemberGetResponse(PartyMember partyMember) {

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -117,6 +117,9 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.party[0].id").value(partyRegisterResponse.id()))
 				.andExpect(jsonPath("$.party[0].name").value(partyRegisterRequest.name()))
 				.andExpect(jsonPath("$.party[0].coverImage").value(partyRegisterRequest.coverImage()))
+				.andExpect(jsonPath("$.party[0].totalMembers").value(1L))
+				.andExpect(jsonPath("$.party[0].members").isArray())
+				.andExpect(jsonPath("$.party[0].members").isNotEmpty())
 				.andExpect(jsonPath("$.lastId").isNotEmpty())
 				.andDo(print());
 	}
@@ -140,6 +143,9 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.endDate").isNotEmpty())    // 위와 동일
 				.andExpect(jsonPath("$.description").value(partyRegisterRequest.description()))
 				.andExpect(jsonPath("$.coverImage").value(partyRegisterRequest.coverImage()))
+				.andExpect(jsonPath("$.totalMembers").value(1L))
+				.andExpect(jsonPath("$.members").isArray())
+				.andExpect(jsonPath("$.members").isNotEmpty())
 				.andDo(print());
 	}
 
@@ -172,6 +178,9 @@ class PartyControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.endDate").isNotEmpty())
 				.andExpect(jsonPath("$.description").value(partyUpdateRequest.description()))
 				.andExpect(jsonPath("$.coverImage").value(partyUpdateRequest.coverImage()))
+				.andExpect(jsonPath("$.totalMembers").value(1L))
+				.andExpect(jsonPath("$.members").isArray())
+				.andExpect(jsonPath("$.members").isNotEmpty())
 				.andDo(print());
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -168,16 +168,27 @@ class PartyServiceTest {
 			//mocking
 			given(partyMemberRepository.findAllByMemberId(member.getId(), null, 1, PartyType.ALL))
 					.willReturn(List.of(partyMember));
+			given(partyMemberRepository.countAllByParty(party))
+					.willReturn(1L);
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 3))
+					.willReturn(List.of(partyMember));
 
 			//when
 			PartyGetAllResponse partyGetAllResponse = partyService.getAllParty(new PartyGetRequest(PartyType.ALL, null, 1));
 
 			//then
 			assertThat(partyGetAllResponse.party()).isNotEmpty();
+			assertThat(partyGetAllResponse.party().get(0).members()).isNotEmpty();
 
 			then(partyMemberRepository)
 					.should()
 					.findAllByMemberId(member.getId(), null, 1, PartyType.ALL);
+			then(partyMemberRepository)
+					.should()
+					.countAllByParty(party);
+			then(partyMemberRepository)
+					.should()
+					.findAllByPartyId(party.getId(), null, 3);
 		}
 
 		@Test
@@ -211,6 +222,10 @@ class PartyServiceTest {
 			//mocking
 			given(partyRepository.findById(party.getId()))
 					.willReturn(Optional.of(party));
+			given(partyMemberRepository.countAllByParty(party))
+					.willReturn(1L);
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 3))
+					.willReturn(List.of(partyMember));
 
 			//when
 			PartyGetResponse myParty = partyService.getParty(party.getId());
@@ -222,10 +237,18 @@ class PartyServiceTest {
 			assertThat(myParty.endDate()).isEqualTo(LocalDate.from(party.getEndDate()));
 			assertThat(myParty.description()).isEqualTo(party.getDescription());
 			assertThat(myParty.coverImage()).isEqualTo(party.getCoverImage());
+			assertThat(myParty.totalMembers()).isEqualTo(1L);
+			assertThat(myParty.members()).isNotEmpty();
 
 			then(partyRepository)
 					.should()
 					.findById(party.getId());
+			then(partyMemberRepository)
+					.should()
+					.countAllByParty(party);
+			then(partyMemberRepository)
+					.should()
+					.findAllByPartyId(party.getId(), null, 3);
 		}
 
 		@Test


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Party 조회시 구성원 및 전체 멤버 수 포함 기능 구현 및 테스트

### ⛏ 중점 사항

- 프론트엔드 요청에 따라 PartyMemberService의 일부 기능이 PartyService에 들어갔습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-283], [WUMO-284]

[WUMO-283]: https://shoekream.atlassian.net/browse/WUMO-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-284]: https://shoekream.atlassian.net/browse/WUMO-284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ