### PR TITLE
[WUMO-288] Route 목록 조회 응답 시 좋아요 여부 추가

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/SortType.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/SortType.java
@@ -1,5 +1,9 @@
 package org.prgrms.wumo.domain.route.dto.request;
 
+import java.util.Arrays;
+
+import javax.validation.ValidationException;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 import lombok.Getter;
@@ -17,11 +21,9 @@ public enum SortType {
 
 	@JsonCreator
 	public static SortType from(String value) {
-		for (SortType sortType : SortType.values()) {
-			if (sortType.getValue().equals(value)) {
-				return sortType;
-			}
-		}
-		return null;
+		return Arrays.stream(SortType.values())
+			.filter(sortType -> sortType.equals(value))
+			.findFirst()
+			.orElseThrow(() -> new ValidationException("올바른 정렬 기준이 아닙니다."));
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
@@ -7,12 +7,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "루트 목록 조회 응답 시 각각의 루트 정보")
 public record RouteGetAllResponse(
-	//TODO 내가 이 루트 좋아요 눌렀는지 여부 같이 보내주기
 	@Schema(description = "루트 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 	long routeId,
 
 	@Schema(description = "루트의 좋아요 수", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
 	long likeCount,
+
+	@Schema(description = "로그인 중인 회원이 이 루트를 좋아요 눌렀는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+	boolean isLiking,
 
 	@Schema(description = "루트의 장소 이름들", requiredMode = Schema.RequiredMode.REQUIRED)
 	List<RouteLocationSimpleResponse> locations,

--- a/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
@@ -10,6 +10,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+import javax.persistence.Transient;
 
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.party.model.Party;
@@ -41,6 +42,9 @@ public class Route extends BaseTimeEntity {
 	@Column(name = "like_count", nullable = true, updatable = true)
 	private long likeCount;
 
+	@Transient
+	private boolean isLiking;
+
 	@Builder
 	public Route(Long id, List<Location> locations, Party party) {
 		this.id = id;
@@ -61,7 +65,7 @@ public class Route extends BaseTimeEntity {
 		this.isPublic = isPublic;
 	}
 
-	public void updateLikeCount() {
-
+	public void addIsLiking(boolean isLiking) {
+		this.isLiking = isLiking;
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepositoryImpl.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepositoryImpl.java
@@ -27,7 +27,9 @@ public class RouteCustomRepositoryImpl implements RouteCustomRepository {
 	@Override
 	public List<Route> findAllByCursorAndSearchWord(Long cursorId, int pageSize, SortType sortType, String searchWord) {
 
-		return jpaQueryFactory.selectFrom(qRoute)
+		//TODO join해서 내가 좋아요 눌렀는지 여부까지 가져올 수 있을지
+		return jpaQueryFactory
+			.selectFrom(qRoute)
 			.where(inRouteAndHasSearchWord(searchWord),
 				ltRouteId(cursorId),
 				isPublic())

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import javax.persistence.EntityNotFoundException;
 
+import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
 import org.prgrms.wumo.domain.party.model.Party;
@@ -37,6 +38,7 @@ public class RouteService {
 	private final PartyRepository partyRepository;
 	private final PartyMemberRepository partyMemberRepository;
 	private final LocationRepository locationRepository;
+	private final RouteLikeRepository routeLikeRepository;
 
 	@Transactional
 	public RouteRegisterResponse registerRoute(RouteRegisterRequest routeRegisterRequest) {
@@ -77,7 +79,9 @@ public class RouteService {
 			routeGetAllRequest.pageSize(),
 			routeGetAllRequest.sortType(),
 			routeGetAllRequest.searchWord());
+		addIsLiking(routes);
 
+		//TODO 현재 모든 목록 조회에서 같은 로직 사용중 -> util로 빼는것 고려하기
 		long lastId = -1L;
 		if (routes.size() != 0) {
 			lastId = routes.get(routes.size() - 1).getId();
@@ -96,6 +100,14 @@ public class RouteService {
 	private Route getRouteEntity(long routeId) {
 		return routeRepository.findById(routeId)
 			.orElseThrow(() -> new EntityNotFoundException("일치하는 루트가 없습니다."));
+	}
+
+	private void addIsLiking(List<Route> routes) {
+		long memberId = getMemberId();
+		routes.forEach(
+			route -> route.addIsLiking(
+				routeLikeRepository.existsByRouteIdAndMemberId(route.getId(), memberId)
+			));
 	}
 
 	private void validateAccess(long partyId) {

--- a/src/main/java/org/prgrms/wumo/global/config/SecurityConfig.java
+++ b/src/main/java/org/prgrms/wumo/global/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.prgrms.wumo.global.jwt.CustomAuthenticationEntryPoint;
 import org.prgrms.wumo.global.jwt.JwtAuthenticationFilter;
 import org.prgrms.wumo.global.jwt.JwtExceptionFilter;
 import org.prgrms.wumo.global.jwt.JwtTokenProvider;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -26,9 +25,6 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
-	@Value("${front.server}")
-	private String frontServer;
 
 	private final JwtProperties jwtProperties;
 	private final ObjectMapper objectMapper;

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -55,6 +55,7 @@ public class RouteMapper {
 			.map(route -> new RouteGetAllResponse(
 				route.getId(),
 				route.getLikeCount(),
+				route.isLiking(),
 				toRouteLocationSimpleResponse(route.getLocations()),
 				route.getParty().getName(),
 				route.getParty().getStartDate(),

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
 import org.prgrms.wumo.domain.location.model.Category;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
@@ -66,6 +67,9 @@ public class RouteServiceTest {
 
 	@Mock
 	PartyMemberRepository partyMemberRepository;
+
+	@Mock
+	RouteLikeRepository routeLikeRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -228,6 +232,8 @@ public class RouteServiceTest {
 			//mocking
 			given(routeRepository.findAllByCursorAndSearchWord(any(), anyInt(), any(SortType.class), any()))
 				.willReturn(routes);
+			given(routeLikeRepository.existsByRouteIdAndMemberId(anyLong(), anyLong()))
+				.willReturn(true);
 
 			//when
 			RouteGetAllResponses result = routeService.getAllRoute(routeGetAllRequest);
@@ -249,6 +255,8 @@ public class RouteServiceTest {
 			//mocking
 			given(routeRepository.findAllByCursorAndSearchWord(any(), anyInt(), any(SortType.class), anyString()))
 				.willReturn(routes);
+			given(routeLikeRepository.existsByRouteIdAndMemberId(anyLong(), anyLong()))
+				.willReturn(true);
 
 			//when
 			RouteGetAllResponses result = routeService.getAllRoute(routeGetAllRequest);


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 좋아요 기능이 추가됨에 따라 루트 목록 조회 응답 시,
 현재 로그인 하고 있는 회원이 해당 루트의 좋아요를 눌렀는지 여부를 같이 보내도록 추가하였습니다

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 현재 RouteService에서 좋아요 눌렀는지 여부(isLiking)의 필드를 하나의 루트마다 for문 안에서 추가해주고 있습니다
추후 join으로 한번에 가져올 수 있을지 고민해 볼 예정입니다
더 좋은 방법이 있을지 같이 고민해주시면 감사하겠습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-298], [WUMO-299]

[WUMO-298]: https://shoekream.atlassian.net/browse/WUMO-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-299]: https://shoekream.atlassian.net/browse/WUMO-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ