### PR TITLE
[WUMO-297] Comment 검증 로직 리팩토링

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/LocationCommentRegisterRequest.java
@@ -18,20 +18,20 @@ public record LocationCommentRegisterRequest(
 		@Schema(description = "댓글이 작성된 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId,
 
-		@NotNull(message = "댓글을 다는 모임에서의 역할 식별자는 필수 입력값입니다.")
-		@Schema(description = "댓글의 모임 역할 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-		Long partyMemberId
+		@NotNull(message = "모임 식별자는 필수 입력값입니다.")
+		@Schema(description = "댓글을 다는 모임 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long partyId
 
 ) {
 	public LocationCommentRegisterRequest(
-			String content, String image, Long locationId, Long partyMemberId
+			String content, String image, Long locationId, Long partyId
 	) {
 		if (content.isEmpty() && image.isEmpty())
-			throw new ValidationException("내용이 빌 수는 없습니다");
+			throw new ValidationException("댓글 내용 또는 이미지 둘 중 하나는 입력해야합니다.");
 
 		this.content = content;
 		this.image = image;
 		this.locationId = locationId;
-		this.partyMemberId = partyMemberId;
+		this.partyId = partyId;
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/PartyRouteCommentRegisterRequest.java
@@ -7,35 +7,30 @@ import javax.validation.constraints.NotNull;
 @Schema(name = "모임 내 루트 댓글 생성 요청")
 public record PartyRouteCommentRegisterRequest(
 
-		@NotNull(message = "댓글 성성 요청자의 식별자는 필수 입력값입니다")
-		@Schema(description = "댓글 생성 요청자 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-		Long memberId,
-
 		@Schema(description = "댓글 내용", example = "댓글", requiredMode = Schema.RequiredMode.REQUIRED)
 		String content,
 
 		@Schema(description = "댓글 이미지 주소", example = "http://~.png", requiredMode = Schema.RequiredMode.REQUIRED)
 		String image,
 
-		@NotNull(message = "댓글이 쓰여지는 일정의 식별자는 필수 입력값입니다.")
-		@Schema(description = "루트 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-		Long routeId,
+		@NotNull(message = "댓글이 쓰여지는 모임의 식별자는 필수 입력값입니다.")
+		@Schema(description = "모임 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long partyId,
 
 		@NotNull(message = "댓글이 쓰여지는 후보지의 식별자는 필수 입력값입니다. ")
 		@Schema(description = "후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 		Long locationId
 ) {
 	public PartyRouteCommentRegisterRequest(
-			Long memberId, String content, String image, Long routeId, Long locationId
+			String content, String image, Long partyId, Long locationId
 	) {
 		if (content.isEmpty() && image.isEmpty()) {
 			throw new ValidationException("댓글에 이미지나 내용 둘 중 하나는 있어야 합니다.");
 		}
 
-		this.memberId = memberId;
 		this.content = content;
 		this.image = image;
-		this.routeId = routeId;
+		this.partyId = partyId;
 		this.locationId = locationId;
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/model/Comment.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/model/Comment.java
@@ -2,6 +2,8 @@ package org.prgrms.wumo.domain.comment.model;
 
 import static lombok.AccessLevel.PROTECTED;
 
+import java.util.Objects;
+
 import javax.persistence.Column;
 import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
@@ -16,6 +18,7 @@ import javax.persistence.Table;
 
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.global.audit.BaseTimeEntity;
+import org.springframework.security.access.AccessDeniedException;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -51,5 +54,11 @@ public class Comment extends BaseTimeEntity {
 
 	public void setMember(Member member) {
 		this.member = member;
+	}
+
+	public void checkAuthorization(Long memberId) {
+		if (!Objects.equals(this.member.getId(), memberId)) {
+			throw new AccessDeniedException("댓글의 수정 및 삭제는 작성자만 할 수 있습니다.");
+		}
 	}
 }

--- a/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
@@ -14,6 +14,7 @@ import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResp
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentUpdateResponse;
 import org.prgrms.wumo.domain.comment.model.LocationComment;
 import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
+import org.prgrms.wumo.domain.party.model.PartyMember;
 
 public class CommentMapper {
 	public static LocationCommentRegisterResponse toLocationCommentRegisterResponse(LocationComment locationcomment) {
@@ -22,12 +23,12 @@ public class CommentMapper {
 		);
 	}
 
-	public static LocationComment toLocationComment(LocationCommentRegisterRequest locationCommentRegisterRequest) {
+	public static LocationComment toLocationComment(LocationCommentRegisterRequest locationCommentRegisterRequest, PartyMember partyMember) {
 		return LocationComment.builder()
 				.locationId(locationCommentRegisterRequest.locationId())
 				.content(locationCommentRegisterRequest.content())
 				.image(locationCommentRegisterRequest.image())
-				.locationId(locationCommentRegisterRequest.locationId())
+				.partyMember(partyMember)
 				.build();
 	}
 
@@ -69,10 +70,10 @@ public class CommentMapper {
 	}
 
 	public static PartyRouteComment toPartyRouteComment(
-			PartyRouteCommentRegisterRequest partyRouteCommentRegisterRequest) {
+			PartyRouteCommentRegisterRequest partyRouteCommentRegisterRequest, Long routeId) {
 		return PartyRouteComment.builder()
 				.locationId(partyRouteCommentRegisterRequest.locationId())
-				.routeId(partyRouteCommentRegisterRequest.routeId())
+				.routeId(routeId)
 				.content(partyRouteCommentRegisterRequest.content())
 				.image(partyRouteCommentRegisterRequest.image())
 				.build();

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
@@ -68,7 +68,7 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 	PartyMemberRepository partyMemberRepository;
 
 	@Autowired
-	private LocationCommentRepository locationCommentRepository;
+	LocationCommentRepository locationCommentRepository;
 
 	// GIVEN
 	Member member;
@@ -156,7 +156,7 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 	void registerLocationComment() throws Exception {
 		// Given
 		LocationCommentRegisterRequest locationCommentRegisterRequest =
-				new LocationCommentRegisterRequest("댓글 댓글", "image.png", location.getId(), partyMember.getId());
+				new LocationCommentRegisterRequest("댓글 댓글", "image.png", location.getId(), party.getId());
 
 		// When
 		ResultActions resultActions =

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -140,6 +140,9 @@ public class PartyRouteCommentControllerTest {
 						.build()
 		);
 
+		location.addRoute(route);
+		location = locationRepository.save(location);
+
 		partyRouteComment = partyRouteCommentRepository.save(
 				PartyRouteComment.builder()
 						.image("image.png")
@@ -175,7 +178,14 @@ public class PartyRouteCommentControllerTest {
 	@DisplayName("모임 내 일정에 댓글을 생성할 수 있다")
 	void registerPartyRouteCommentTest() throws Exception {
 		// Given
-		PartyRouteCommentRegisterRequest request = new PartyRouteCommentRegisterRequest(
+
+		System.out.println("-=--==-==============---=-===-=-=-=");
+		System.out.println(location.getRoute().getId());
+		System.out.println(location.getId());
+		System.out.println("--------------------=-=-=-=-=-=-=-=");
+		System.out.println(route.getId());
+
+		PartyRouteCommentRegisterRequest partyRouteCommentRegisterRequest = new PartyRouteCommentRegisterRequest(
 				"모임 내 댓글", "image.png", party.getId(), location.getId()
 		);
 
@@ -186,7 +196,7 @@ public class PartyRouteCommentControllerTest {
 								.contentType(MediaType.APPLICATION_JSON_VALUE)
 								.characterEncoding("UTF-8")
 								.content(
-										objectMapper.writeValueAsString(request)
+										objectMapper.writeValueAsString(partyRouteCommentRegisterRequest)
 								)
 				);
 

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -179,12 +179,6 @@ public class PartyRouteCommentControllerTest {
 	void registerPartyRouteCommentTest() throws Exception {
 		// Given
 
-		System.out.println("-=--==-==============---=-===-=-=-=");
-		System.out.println(location.getRoute().getId());
-		System.out.println(location.getId());
-		System.out.println("--------------------=-=-=-=-=-=-=-=");
-		System.out.println(route.getId());
-
 		PartyRouteCommentRegisterRequest partyRouteCommentRegisterRequest = new PartyRouteCommentRegisterRequest(
 				"모임 내 댓글", "image.png", party.getId(), location.getId()
 		);

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -176,7 +176,7 @@ public class PartyRouteCommentControllerTest {
 	void registerPartyRouteCommentTest() throws Exception {
 		// Given
 		PartyRouteCommentRegisterRequest request = new PartyRouteCommentRegisterRequest(
-				member.getId(), "모임 내 댓글", "image.png", route.getId(), location.getId()
+				"모임 내 댓글", "image.png", party.getId(), location.getId()
 		);
 
 		// When

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
@@ -32,7 +32,6 @@ import org.prgrms.wumo.domain.comment.repository.LocationCommentRepository;
 import org.prgrms.wumo.domain.location.model.Category;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.member.model.Member;
-import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
@@ -50,9 +49,6 @@ public class LocationCommentServiceTest {
 
 	@Mock
 	LocationCommentRepository locationCommentRepository;
-
-	@Mock
-	MemberRepository memberRepository;
 
 	@Mock
 	PartyMemberRepository partyMemberRepository;
@@ -95,10 +91,10 @@ public class LocationCommentServiceTest {
 			// Given
 			LocationCommentRegisterRequest locationCommentRegisterRequest =
 					new LocationCommentRegisterRequest(locationComment.getContent(), locationComment.getImage(),
-							locationComment.getLocationId(), locationComment.getPartyMember().getId());
+							locationComment.getLocationId(), party.getId());
 
-			given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-			given(partyMemberRepository.findById(any(Long.class))).willReturn(Optional.of(partyMember));
+			given(partyMemberRepository.findByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(
+					Optional.of(partyMember));
 			given(locationCommentRepository.save(any(LocationComment.class))).willReturn(locationComment);
 
 			// When
@@ -165,8 +161,8 @@ public class LocationCommentServiceTest {
 		@DisplayName("후보지 댓글을 수정한다.")
 		void success() {
 			// Given
-			given(partyMemberRepository.existsById(any(Long.class))).willReturn(true);
 			given(locationCommentRepository.findById(any(Long.class))).willReturn(Optional.of(locationComment));
+			given(partyMemberRepository.existsById(any(Long.class))).willReturn(true);
 			given(locationCommentRepository.save(any(LocationComment.class))).willReturn(locationComment);
 
 			LocationCommentUpdateRequest request =

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
@@ -103,7 +103,7 @@ public class PartyRouteCommentServiceTest {
 		void success() {
 			// Given
 			PartyRouteCommentRegisterRequest request = new PartyRouteCommentRegisterRequest(
-					1L, "모임 내 댓글", "image.png", 1L, 1L
+					"모임 내 댓글", "image.png", party.getId(), location.getId()
 			);
 
 			given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(member));

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.then;
 import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentGetAllResponse;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -33,12 +34,10 @@ import org.prgrms.wumo.domain.location.model.Category;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
 import org.prgrms.wumo.domain.member.model.Member;
-import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.route.model.Route;
-import org.prgrms.wumo.domain.route.repository.RouteRepository;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
@@ -55,16 +54,10 @@ public class PartyRouteCommentServiceTest {
 	PartyRouteCommentRepository partyRouteCommentRepository;
 
 	@Mock
-	MemberRepository memberRepository;
-
-	@Mock
 	PartyMemberRepository partyMemberRepository;
 
 	@Mock
 	LocationRepository locationRepository;
-
-	@Mock
-	RouteRepository routeRepository;
 
 	// GIVEN
 	Member member;
@@ -73,14 +66,17 @@ public class PartyRouteCommentServiceTest {
 	PartyRouteComment partyRouteComment;
 	Route route;
 	Location location;
+	List<Location> locations = new ArrayList<>();
 
 	@BeforeEach
 	void beforeEach() {
 		member = getMember();
 		party = getParty();
 		location = getLocation();
+		locations.add(location);
 		partyMember = getPartyMember();
-		route = getRoute();
+		route = getRoute(locations);
+		location.addRoute(route);
 		partyRouteComment = getPartyRouteComment();
 
 		SecurityContext context = SecurityContextHolder.getContext();
@@ -92,6 +88,7 @@ public class PartyRouteCommentServiceTest {
 
 	@AfterEach
 	void afterEach() {
+		locations.clear();
 		SecurityContextHolder.clearContext();
 	}
 
@@ -106,11 +103,9 @@ public class PartyRouteCommentServiceTest {
 					"모임 내 댓글", "image.png", party.getId(), location.getId()
 			);
 
-			given(memberRepository.findById(any(Long.class))).willReturn(Optional.of(member));
+			given(locationRepository.findById(any(Long.class))).willReturn(Optional.of(location));
 			given(partyMemberRepository.findByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(
 					Optional.of(partyMember));
-			given(routeRepository.findById(any(Long.class))).willReturn(Optional.of(route));
-			given(locationRepository.existsById(any(Long.class))).willReturn(true);
 			given(partyRouteCommentRepository.save(any(PartyRouteComment.class))).willReturn(partyRouteComment);
 
 			// When
@@ -217,14 +212,14 @@ public class PartyRouteCommentServiceTest {
 		void success() {
 			// Given
 			PartyRouteComment tmp = PartyRouteComment.builder()
-				.id(450L)
-				.image("image.png")
-				.content("삭제될 댓글....")
-				.locationId(location.getId())
-				.routeId(route.getId())
-				.partyMember(partyMember)
-				.member(member)
-				.build();
+					.id(450L)
+					.image("image.png")
+					.content("삭제될 댓글....")
+					.locationId(location.getId())
+					.routeId(route.getId())
+					.partyMember(partyMember)
+					.member(member)
+					.build();
 
 			given(partyMemberRepository.existsById(any(Long.class))).willReturn(true);
 			given(partyRouteCommentRepository.findById(any(Long.class))).willReturn(Optional.of(tmp));
@@ -241,14 +236,14 @@ public class PartyRouteCommentServiceTest {
 		void failedByOtherMember() {
 			// Given
 			PartyRouteComment tmp = PartyRouteComment.builder()
-				.id(450L)
-				.image("image.png")
-				.content("삭제될 댓글....")
-				.locationId(location.getId())
-				.routeId(route.getId())
-				.partyMember(partyMember)
-				.member(member)
-				.build();
+					.id(450L)
+					.image("image.png")
+					.content("삭제될 댓글....")
+					.locationId(location.getId())
+					.routeId(route.getId())
+					.partyMember(partyMember)
+					.member(member)
+					.build();
 
 			given(partyMemberRepository.existsById(any(Long.class))).willReturn(false);
 			given(partyRouteCommentRepository.findById(any(Long.class))).willReturn(Optional.of(tmp));
@@ -302,11 +297,11 @@ public class PartyRouteCommentServiceTest {
 				.build();
 	}
 
-	private Route getRoute() {
+	private Route getRoute(List<Location> locations) {
 		return Route.builder()
 				.id(1L)
 				.party(party)
-				.locations(List.of())
+				.locations(locations)
 				.build();
 	}
 
@@ -324,6 +319,8 @@ public class PartyRouteCommentServiceTest {
 				.latitude(67.89F)
 				.category(Category.DRINK)
 				.visitDate(LocalDateTime.now())
+				.route(route)
 				.build();
 	}
 }
+


### PR DESCRIPTION
### 📝 작업 요약

댓글에서 사용자를 검증 방식 리팩토링

### ⛏ 중점 사항

최대한 적은 Repository를 주입받고자 리팩토링을 진행했습니다
- 기존 getMemberEntity 로 Member 주입 -> partyMember.member 로 대체
- 댓글 작성자와 현재 접속중인 사람을 확인하는 메소드를 comment entity 내부로 위치 이동
- 기존 수정 및 삭제시 댓글 작성자 확인 + 모임 내 멤버 검증을 진행하는 메소드가 분리되어있던 것을 하나의 메소드로 묶음

추가로 댓글 등록 요청 dto의 필드에서 
- memberId 제거,
- roueId -> partyId 로 변경
의 작업을 진행했습니다.

### 💡 관련 이슈

- Resolved : [이슈번호], [이슈번호]