### PR TITLE
[WUMO-287] Route 상세 조회 기능 요구사항 반영

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
@@ -41,14 +41,13 @@ public class RouteController {
 		return new ResponseEntity<>(routeService.registerRoute(routeRegisterRequest), HttpStatus.CREATED);
 	}
 
-	@GetMapping("/{routeId}")
+	@GetMapping("/{partyId}")
 	@Operation(summary = "루트 상세 조회")
 	public ResponseEntity<RouteGetResponse> getRoute(
-		//TODO routeId -> partyId로 바꾸기
-		@PathVariable @Parameter(description = "조회할 루트 아이디") long routeId,
+		@PathVariable @Parameter(description = "조회할 루트가 포함된 모임 아이디") long partyId,
 		@RequestParam("path") @Parameter(description = "접근 경로(모임에서이면 0, 공개 목록에서이면 1)") int fromPublic) {
 
-		return ResponseEntity.ok(routeService.getRoute(routeId, fromPublic));
+		return ResponseEntity.ok(routeService.getRoute(partyId, fromPublic));
 	}
 
 	@GetMapping

--- a/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/model/Route.java
@@ -9,6 +9,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 
@@ -34,6 +35,7 @@ public class Route extends BaseTimeEntity {
 	private boolean isPublic;
 
 	@OneToMany(mappedBy = "route")
+	@OrderBy(value = "visitDate DESC")
 	private List<Location> locations;
 
 	@OneToOne

--- a/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepository.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.route.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.prgrms.wumo.domain.route.dto.request.SortType;
 import org.prgrms.wumo.domain.route.model.Route;
@@ -8,4 +9,6 @@ import org.prgrms.wumo.domain.route.model.Route;
 public interface RouteCustomRepository {
 
 	List<Route> findAllByCursorAndSearchWord(Long cursorId, int pageSize, SortType sortType, String searchWord);
+
+	Optional<Route> findByPartyId(long partyId);
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepositoryImpl.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.route.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.prgrms.wumo.domain.location.model.QLocation;
 import org.prgrms.wumo.domain.route.dto.request.SortType;
@@ -36,6 +37,15 @@ public class RouteCustomRepositoryImpl implements RouteCustomRepository {
 			.orderBy(getSortType(sortType))
 			.limit(pageSize)
 			.fetch();
+	}
+
+	@Override
+	public Optional<Route> findByPartyId(long partyId) {
+		Route route = jpaQueryFactory
+			.selectFrom(qRoute)
+			.where(qRoute.party.id.eq(partyId))
+			.fetchFirst();
+		return Optional.ofNullable(route);
 	}
 
 	private BooleanExpression inRouteAndHasSearchWord(String searchWord) {

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -62,8 +62,9 @@ public class RouteService {
 	}
 
 	@Transactional(readOnly = true)
-	public RouteGetResponse getRoute(long routeId, int fromPublic) {
-		Route route = getRouteEntity(routeId);
+	public RouteGetResponse getRoute(long partyId, int fromPublic) {
+		Route route = routeRepository.findByPartyId(partyId)
+			.orElseThrow(() -> new EntityNotFoundException("일치하는 루트가 없습니다."));
 
 		if (fromPublic == 0) {
 			validateAccess(route.getParty().getId());

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -1,7 +1,6 @@
 package org.prgrms.wumo.global.mapper;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 
 import org.prgrms.wumo.domain.location.model.Location;
@@ -35,7 +34,6 @@ public class RouteMapper {
 
 	public static RouteGetResponse toRouteGetResponse(Route route) {
 		List<RouteLocationResponse> routeLocations = route.getLocations().stream()
-			.sorted(Comparator.comparing(Location::getVisitDate))
 			.map(location -> new RouteLocationResponse(
 				location.getId(),
 				location.getName(),
@@ -70,7 +68,6 @@ public class RouteMapper {
 
 	private static List<RouteLocationSimpleResponse> toRouteLocationSimpleResponse(List<Location> locations) {
 		return locations.stream()
-			.sorted(Comparator.comparing(Location::getVisitDate))
 			.map(location -> new RouteLocationSimpleResponse(
 				location.getId(),
 				location.getName(),

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.global.mapper;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 import org.prgrms.wumo.domain.location.model.Location;
@@ -34,6 +35,7 @@ public class RouteMapper {
 
 	public static RouteGetResponse toRouteGetResponse(Route route) {
 		List<RouteLocationResponse> routeLocations = route.getLocations().stream()
+			.sorted(Comparator.comparing(Location::getVisitDate))
 			.map(location -> new RouteLocationResponse(
 				location.getId(),
 				location.getName(),
@@ -68,6 +70,7 @@ public class RouteMapper {
 
 	private static List<RouteLocationSimpleResponse> toRouteLocationSimpleResponse(List<Location> locations) {
 		return locations.stream()
+			.sorted(Comparator.comparing(Location::getVisitDate))
 			.map(location -> new RouteLocationSimpleResponse(
 				location.getId(),
 				location.getName(),

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -134,7 +134,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 	void get_route_in_party() throws Exception {
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/{routeId}", routeId)
+			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/{partyId}", partyId)
 			.param("path", "0"));
 
 		//then
@@ -152,7 +152,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 	void get_route_from_public_list() throws Exception {
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/{routeId}", routeId)
+			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/{partyId}", partyId)
 			.param("path", "1"));
 
 		//then

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -182,11 +182,11 @@ public class RouteServiceTest {
 			int isPublic = 0;
 
 			//mocking
-			given(routeRepository.findById(anyLong()))
+			given(routeRepository.findByPartyId(anyLong()))
 				.willReturn(Optional.of(route));
 
 			//when, then
-			assertThatThrownBy(() -> routeService.getRoute(routeId, isPublic))
+			assertThatThrownBy(() -> routeService.getRoute(partyId, isPublic))
 				.isInstanceOf(AccessDeniedException.class)
 				.hasMessage("잘못된 접근입니다.");
 		}
@@ -199,18 +199,18 @@ public class RouteServiceTest {
 			int isPublic = 1;
 
 			//mocking
-			given(routeRepository.findById(anyLong()))
+			given(routeRepository.findByPartyId(anyLong()))
 				.willReturn(Optional.of(route));
 
 			//when
-			RouteGetResponse result = routeService.getRoute(routeId, isPublic);
+			RouteGetResponse result = routeService.getRoute(partyId, isPublic);
 
 			//then
 			assertThat(result.partyId()).isEqualTo(partyId);
 			assertThat(result.locations()).hasSize(1);
 			then(routeRepository)
 				.should()
-				.findById(anyLong());
+				.findByPartyId(anyLong());
 		}
 	}
 


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

루트 상세 조회 기능 요구사항 반영
- 루트 식별자로 조회가 아닌(프론트에서 루트 식별자를 알 방법이 없음)
루트가 속한 모임의 식별자로 루트의 상세 조회를 요청하게 됩니다
- 응답 시에는 루트 안의 후보지들의 정렬 기준을 방문일로 구현하였습니다

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 현재 JPA를 활용해 루트 안의 후보지들을 lazy loading으로 가져오기 때문에 application단에서 방문일 기준으로 정렬하는 과정도 가능합니다
- 지금 구현한 방법(order by 사용)과 비교했을 때 현재의 데이터 크기로는 큰 차이가 없었으나 여건이 된다면 추후 더 큰 데이터로도 비교해볼 예정입니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-310], [WUMO-311], [WUMO-312]

[WUMO-310]: https://shoekream.atlassian.net/browse/WUMO-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-311]: https://shoekream.atlassian.net/browse/WUMO-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-312]: https://shoekream.atlassian.net/browse/WUMO-312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ