### PR TITLE
[WUMO-307] Location 실제 사용 금액 갱신 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/location/api/LocationController.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/api/LocationController.java
@@ -44,10 +44,11 @@ public class LocationController {
 		return new ResponseEntity<>(locationService.registerLocation(locationRegisterRequest), HttpStatus.CREATED);
 	}
 
+
 	@GetMapping("/{locationId}")
 	@Operation(summary = "후보지 상세 조회")
 	public ResponseEntity<LocationGetResponse> getLocation(
-			@PathVariable @Parameter(description = "조회할 후보장소 아이디") Long locationId) {
+			@PathVariable @Parameter(description = "조회할 후보지 식별자") Long locationId) {
 
 		return ResponseEntity.ok(locationService.getLocation(locationId));
 	}
@@ -64,7 +65,7 @@ public class LocationController {
 	public ResponseEntity<LocationSpendingUpdateResponse> updateSpending(
 			@RequestBody @Valid LocationSpendingUpdateRequest locationSpendingUpdateRequest
 	) {
-		return ResponseEntity.ok(null);
+		return ResponseEntity.ok(locationService.updateSpending(locationSpendingUpdateRequest));
 	}
 
 	@PatchMapping
@@ -78,7 +79,7 @@ public class LocationController {
 	@DeleteMapping("/{locationId}")
 	@Operation(summary = "후보지 삭제")
 	public ResponseEntity<Void> deleteLocation(
-			@PathVariable @Parameter(description = "삭제할 후보장소 아이디") Long locationId) {
+			@PathVariable @Parameter(description = "삭제할 후보지 식별자") Long locationId) {
 
 		locationService.deleteLocation(locationId);
 		return ResponseEntity.ok().build();

--- a/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
@@ -110,4 +110,8 @@ public class Location extends BaseTimeEntity {
 		this.expectedCost = request.expectedCost();
 		this.description = request.description() == null ? this.getDescription() : request.description();
 	}
+
+	public void updateSpending(int spending) {
+		this.spending = spending;
+	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -5,6 +5,7 @@ import static org.prgrms.wumo.global.mapper.LocationMapper.toLocation;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetAllResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationRegisterResponse;
+import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationSpendingUpdateResponse;
 import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationUpdateResponse;
 
 import java.util.List;
@@ -13,10 +14,12 @@ import javax.persistence.EntityNotFoundException;
 
 import org.prgrms.wumo.domain.location.dto.request.LocationGetAllRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
+import org.prgrms.wumo.domain.location.dto.request.LocationSpendingUpdateRequest;
 import org.prgrms.wumo.domain.location.dto.request.LocationUpdateRequest;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
+import org.prgrms.wumo.domain.location.dto.response.LocationSpendingUpdateResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationUpdateResponse;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
@@ -83,6 +86,19 @@ public class LocationService {
 		checkMemberInParty(location.getPartyId(), getMemberId());
 
 		locationRepository.deleteById(locationId);
+	}
+
+	@Transactional
+	public LocationSpendingUpdateResponse updateSpending(LocationSpendingUpdateRequest locationSpendingUpdateRequest){
+		Location location = getLocationEntity(locationSpendingUpdateRequest.locationId());
+
+		checkMemberInParty(location.getPartyId(), getMemberId());
+
+		location.updateSpending(locationSpendingUpdateRequest.spending());
+
+		locationRepository.save(location);
+
+		return toLocationSpendingUpdateResponse(location.getSpending());
 	}
 
 	private Location getLocationEntity(Long locationId) {

--- a/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
@@ -5,6 +5,7 @@ import org.prgrms.wumo.domain.location.dto.request.LocationRegisterRequest;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetAllResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationGetResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationRegisterResponse;
+import org.prgrms.wumo.domain.location.dto.response.LocationSpendingUpdateResponse;
 import org.prgrms.wumo.domain.location.dto.response.LocationUpdateResponse;
 import org.prgrms.wumo.domain.location.model.Location;
 
@@ -65,6 +66,9 @@ public class LocationMapper {
 				location.getExpectedCost(),
 				location.getCategory()
 		);
+	}
 
+	public static LocationSpendingUpdateResponse toLocationSpendingUpdateResponse(int spending){
+		return new LocationSpendingUpdateResponse(spending);
 	}
 }


### PR DESCRIPTION
### 📝 작업 요약

후보지 실제 사용 금액 갱신 기능 구현 및 테스트

### ⛏ 중점 사항

후보지 실제 사용 금액 갱신 기능입니다.
현재는 모임 내 인원이면 모두 갱신이 가능한데, 
곧 후보지를 올린 사람 및 모임장만 갱신할 수 있도록 로직 개선 예정입니다

### 💡 관련 이슈

- Resolved : WUMO-308, WUMO-309