### PR TITLE
[WUMO-316] Image 서비스 책임 변경

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
@@ -1,0 +1,95 @@
+package org.prgrms.wumo.domain.image.repository;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.prgrms.wumo.global.exception.custom.ImageDeleteFailedException;
+import org.prgrms.wumo.global.exception.custom.ImageUploadFailedException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Repository
+public class ImageRepository {
+
+	private final String bucket;
+
+	private final AmazonS3 amazonS3;
+
+	private final String BUCKET_URL;
+
+	public ImageRepository(@Value("${cloud.aws.s3.bucket:#{null}}") String bucket, AmazonS3 amazonS3) {
+		this.bucket = Objects.requireNonNull(bucket, "AWS S3 Bucket 정보를 불러오지 못했습니다.");
+		this.amazonS3 = amazonS3;
+		this.BUCKET_URL = String.format("%s.s3.%s.amazonaws.com", bucket, amazonS3.getBucketLocation(bucket));
+	}
+
+	public String save(MultipartFile multipartFile) {
+		if (!validateContentType(multipartFile)) {
+			throw new IllegalArgumentException("이미지가 아닌 데이터를 요청했습니다.");
+		}
+
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+
+		try {
+			objectMetadata.setContentType(multipartFile.getContentType());
+			objectMetadata.setContentLength(multipartFile.getInputStream().available());
+			String uniqueName = getUniqueName(multipartFile.getOriginalFilename());
+
+			amazonS3.putObject(bucket, uniqueName, multipartFile.getInputStream(), objectMetadata);
+			return amazonS3.getUrl(bucket, uniqueName).toString();
+		} catch (IOException e) {
+			throw new ImageUploadFailedException("버킷에 이미지 업로드를 실패했습니다.");
+		}
+	}
+
+	public void delete(String imageUrl) {
+		try {
+			String imageUrlWithHost = removeProtocols(imageUrl);
+			validateHost(imageUrlWithHost);
+
+			amazonS3.deleteObject(bucket, removeHost(imageUrlWithHost));
+		} catch (AmazonServiceException e) {
+			throw new ImageDeleteFailedException("버킷에서 이미지 삭제에 실패했습니다.");
+		}
+	}
+
+	private boolean validateContentType(MultipartFile multipartFile) {
+		return multipartFile.getContentType().startsWith("image/");
+	}
+
+	private String getUniqueName(String originName) {
+		try {
+			String date = LocalDate.now(ZoneId.of("Asia/Tokyo")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+			return String.format("%s/%s%s", date, UUID.randomUUID(), originName.substring(originName.lastIndexOf(".")));
+		} catch (Exception e) {
+			throw new IllegalArgumentException("올바르지 않은 파일명 또는 형식입니다.");
+		}
+	}
+
+	private String removeProtocols(String imageUrl) {
+		return imageUrl.replaceAll("(http|https)://", "");
+	}
+
+	private void validateHost(String imageUrl) {
+		if (!imageUrl.substring(0, imageUrl.indexOf("/")).equals(BUCKET_URL)) {
+			log.info("버킷에 저장되지 않은 이미지를 삭제 요청했습니다. ({})", imageUrl);
+		}
+	}
+
+	private String removeHost(String imageUrl) {
+		return imageUrl.substring(imageUrl.indexOf("/") + 1);
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Objects;
 import java.util.UUID;
 
 import org.prgrms.wumo.global.exception.custom.ImageDeleteFailedException;
@@ -29,8 +28,12 @@ public class ImageRepository {
 
 	private final String BUCKET_URL;
 
-	public ImageRepository(@Value("${cloud.aws.s3.bucket:#{null}}") String bucket, AmazonS3 amazonS3) {
-		this.bucket = Objects.requireNonNull(bucket, "AWS S3 Bucket 정보를 불러오지 못했습니다.");
+	public ImageRepository(@Value("${cloud.aws.s3.bucket:#{''}}") String bucket, AmazonS3 amazonS3) {
+		if (bucket.isBlank()) {
+			log.error("AWS S3 Bucket 정보를 불러오지 못했습니다.");
+		}
+
+		this.bucket = bucket;
 		this.amazonS3 = amazonS3;
 		this.BUCKET_URL = String.format("%s.s3.%s.amazonaws.com", bucket, amazonS3.getBucketLocation(bucket));
 	}

--- a/src/main/java/org/prgrms/wumo/domain/image/service/ImageService.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/service/ImageService.java
@@ -2,103 +2,26 @@ package org.prgrms.wumo.domain.image.service;
 
 import static org.prgrms.wumo.global.mapper.ImageMapper.toImageRegisterResponse;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.Objects;
-import java.util.UUID;
-
 import org.prgrms.wumo.domain.image.dto.request.ImageDeleteRequest;
 import org.prgrms.wumo.domain.image.dto.request.ImageRegisterRequest;
 import org.prgrms.wumo.domain.image.dto.response.ImageRegisterResponse;
-import org.prgrms.wumo.global.exception.custom.ImageDeleteFailedException;
-import org.prgrms.wumo.global.exception.custom.ImageUploadFailedException;
-import org.springframework.beans.factory.annotation.Value;
+import org.prgrms.wumo.domain.image.repository.ImageRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.web.multipart.MultipartFile;
 
-import com.amazonaws.AmazonServiceException;
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-
-import lombok.extern.slf4j.Slf4j;
+import lombok.RequiredArgsConstructor;
 
 @Service
-@Slf4j
+@RequiredArgsConstructor
 public class ImageService {
 
-	private final String bucket;
-
-	private final AmazonS3 amazonS3;
-
-	private final String BUCKET_URL;
-
-	public ImageService(@Value("${cloud.aws.s3.bucket:#{null}}") String bucket, AmazonS3 amazonS3) {
-		this.bucket = Objects.requireNonNull(bucket, "AWS S3 Bucket 정보를 불러오지 못했습니다.");
-		this.amazonS3 = amazonS3;
-		this.BUCKET_URL = String.format("%s.s3.%s.amazonaws.com", bucket, amazonS3.getBucketLocation(bucket));
-	}
+	private final ImageRepository imageRepository;
 
 	public ImageRegisterResponse registerImage(ImageRegisterRequest imageRegisterRequest) {
-		if (!validateContentType(imageRegisterRequest.image())) {
-			throw new IllegalArgumentException("이미지가 아닌 데이터를 요청했습니다.");
-		}
-
-		return toImageRegisterResponse(uploadImage(imageRegisterRequest.image()));
+		return toImageRegisterResponse(imageRepository.save(imageRegisterRequest.image()));
 	}
 
 	public void deleteImage(ImageDeleteRequest imageDeleteRequest) {
-		try {
-			String imageUrlWithHost = removeProtocols(imageDeleteRequest.imageUrl());
-			validateHost(imageUrlWithHost);
-
-			amazonS3.deleteObject(bucket, removeHost(imageUrlWithHost));
-		} catch (AmazonServiceException e) {
-			throw new ImageDeleteFailedException("버킷에서 이미지 삭제에 실패했습니다.");
-		}
-	}
-
-	private boolean validateContentType(MultipartFile multipartFile) {
-		return multipartFile.getContentType().startsWith("image/");
-	}
-
-	private String uploadImage(MultipartFile multipartFile) {
-		ObjectMetadata objectMetadata = new ObjectMetadata();
-
-		try {
-			objectMetadata.setContentType(multipartFile.getContentType());
-			objectMetadata.setContentLength(multipartFile.getInputStream().available());
-			String uniqueName = getUniqueName(multipartFile.getOriginalFilename());
-
-			amazonS3.putObject(bucket, uniqueName, multipartFile.getInputStream(), objectMetadata);
-			return amazonS3.getUrl(bucket, uniqueName).toString();
-		} catch (IOException e) {
-			throw new ImageUploadFailedException("버킷에 이미지 업로드를 실패했습니다.");
-		}
-	}
-
-	private String getUniqueName(String originName) {
-		try {
-			String date = LocalDate.now(ZoneId.of("Asia/Tokyo")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-			return String.format("%s/%s%s", date, UUID.randomUUID(), originName.substring(originName.lastIndexOf(".")));
-		} catch (Exception e) {
-			throw new IllegalArgumentException("올바르지 않은 파일명 또는 형식입니다.");
-		}
-	}
-
-	private String removeProtocols(String imageUrl) {
-		return imageUrl.replaceAll("(http|https)://", "");
-	}
-
-	private void validateHost(String imageUrl) {
-		if (!imageUrl.substring(0, imageUrl.indexOf("/")).equals(BUCKET_URL)) {
-			throw new ImageDeleteFailedException("버킷에 저장된 이미지가 아닙니다.");
-		}
-	}
-
-	private String removeHost(String imageUrl) {
-		return imageUrl.substring(imageUrl.indexOf("/") + 1);
+		imageRepository.delete(imageDeleteRequest.imageUrl());
 	}
 
 }

--- a/src/test/java/org/prgrms/wumo/domain/image/api/ImageControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/image/api/ImageControllerTest.java
@@ -100,22 +100,4 @@ class ImageControllerTest {
 				.andDo(print());
 	}
 
-	@Test
-	@DisplayName("버킷의 이미지 URL이 아니면 오류가 발생한다.")
-	void deleteImageFromInvalidHost() throws Exception {
-		//given (유효하지 않은 이미지 경로 사용)
-		ImageDeleteRequest imageDeleteRequest
-				= new ImageDeleteRequest("http://localhost/test.png");
-
-		//when
-		ResultActions resultActions = mockMvc.perform(delete("/api/v1/images")
-				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.content(objectMapper.writeValueAsString(imageDeleteRequest)));
-
-		//then
-		resultActions
-				.andExpect(status().isBadRequest())
-				.andDo(print());
-	}
-
 }


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Image 서비스 책임 변경 (Service -> Repository)

### ⛏ 중점 사항

- 계층형 아키텍처에 맞게 구조를 변경했습니다.
- 추후 이미지를 사용하는 각 서비스에서 도메인 엔티티 삭제시 이미지 삭제 요청은 Repository로 전달합니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-316]

[WUMO-316]: https://shoekream.atlassian.net/browse/WUMO-316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ