### PR TITLE
[WUMO-323] Location 수정 및 삭제 권한 변경

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
@@ -1,6 +1,7 @@
 package org.prgrms.wumo.domain.location.model;
 
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -17,6 +18,7 @@ import javax.persistence.Table;
 import org.prgrms.wumo.domain.location.dto.request.LocationUpdateRequest;
 import org.prgrms.wumo.domain.route.model.Route;
 import org.prgrms.wumo.global.audit.BaseTimeEntity;
+import org.springframework.security.access.AccessDeniedException;
 
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -117,5 +119,10 @@ public class Location extends BaseTimeEntity {
 
 	public void updateSpending(int spending) {
 		this.spending = spending;
+	}
+
+	public void checkAuthorization(Long memberId){
+		if (!Objects.equals(this.memberId, memberId))
+			throw new AccessDeniedException("후보지는 작성자 및 모임장만 삭제할 수 있습니다.");
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
@@ -33,6 +33,9 @@ public class Location extends BaseTimeEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(name = "member_id", nullable = false, updatable = false, unique = false)
+	Long memberId;
+
 	@Column(name = "name", nullable = false, updatable = true, unique = false)
 	private String name;
 
@@ -75,11 +78,12 @@ public class Location extends BaseTimeEntity {
 	private Long partyId;
 
 	@Builder
-	public Location(Long id, String name, String address, String searchAddress, Float latitude, Float longitude,
+	public Location(Long id, Long memberId, String name, String address, String searchAddress, Float latitude, Float longitude,
 			String image,
 			String description,
 			LocalDateTime visitDate, int expectedCost, int spending, Category category, Route route, Long partyId) {
 		this.id = id;
+		this.memberId = memberId;
 		this.name = name;
 		this.searchAddress = searchAddress;
 		this.address = address;

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -39,7 +39,7 @@ public class LocationService {
 
 	@Transactional
 	public LocationRegisterResponse registerLocation(LocationRegisterRequest locationRegisterRequest) {
-		return toLocationRegisterResponse(locationRepository.save(toLocation(locationRegisterRequest)));
+		return toLocationRegisterResponse(locationRepository.save(toLocation(locationRegisterRequest, getMemberId())));
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -87,6 +87,8 @@ public class LocationService {
 	public void deleteLocation(Long locationId){
 		Location location = getLocationEntity(locationId);
 
+		checkAuthorization(location, getMemberId());
+
 		locationRepository.deleteById(locationId);
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -23,6 +23,7 @@ import org.prgrms.wumo.domain.location.dto.response.LocationSpendingUpdateRespon
 import org.prgrms.wumo.domain.location.dto.response.LocationUpdateResponse;
 import org.prgrms.wumo.domain.location.model.Location;
 import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -39,6 +40,9 @@ public class LocationService {
 
 	@Transactional
 	public LocationRegisterResponse registerLocation(LocationRegisterRequest locationRegisterRequest) {
+
+		checkMemberInParty(locationRegisterRequest.partyId(), getMemberId());
+
 		return toLocationRegisterResponse(locationRepository.save(toLocation(locationRegisterRequest, getMemberId())));
 	}
 
@@ -59,10 +63,10 @@ public class LocationService {
 
 	@Transactional
 	public LocationUpdateResponse updateLocation(LocationUpdateRequest locationUpdateRequest) {
-
-		checkMemberInParty(locationUpdateRequest.partyId(), getMemberId());
-
 		Location location = getLocationEntity(locationUpdateRequest.id());
+
+		checkAuthorization(location, getMemberId());
+
 		location.update(locationUpdateRequest);
 
 		locationRepository.save(location);
@@ -74,7 +78,7 @@ public class LocationService {
 	public void deleteRouteLocation(long locationId) {
 		Location location = getLocationEntity(locationId);
 
-		checkMemberInParty(location.getPartyId(), getMemberId());
+		checkAuthorization(location, getMemberId());
 
 		location.deleteRoute();
 	}
@@ -83,8 +87,6 @@ public class LocationService {
 	public void deleteLocation(Long locationId){
 		Location location = getLocationEntity(locationId);
 
-		checkMemberInParty(location.getPartyId(), getMemberId());
-
 		locationRepository.deleteById(locationId);
 	}
 
@@ -92,7 +94,7 @@ public class LocationService {
 	public LocationSpendingUpdateResponse updateSpending(LocationSpendingUpdateRequest locationSpendingUpdateRequest){
 		Location location = getLocationEntity(locationSpendingUpdateRequest.locationId());
 
-		checkMemberInParty(location.getPartyId(), getMemberId());
+		checkAuthorization(location, getMemberId());
 
 		location.updateSpending(locationSpendingUpdateRequest.spending());
 
@@ -109,5 +111,18 @@ public class LocationService {
 	private void checkMemberInParty(Long partyId, Long memberId) {
 		if (!partyMemberRepository.existsByPartyIdAndMemberId(partyId, memberId))
 			throw new AccessDeniedException("모임에 속하지 않은 회원입니다.");
+	}
+
+	private PartyMember getPartyMemberEntity(Long partyId, Long memberId){
+		return partyMemberRepository.findByPartyIdAndMemberId(partyId, memberId)
+				.orElseThrow(() -> new EntityNotFoundException("모임 내 존재하지 않는 회원입니다."));
+	}
+
+	private void checkAuthorization(Location location, Long memberId){
+		PartyMember partyMember = getPartyMemberEntity(location.getPartyId(), memberId);
+		if (partyMember.isLeader())
+			return;
+		checkMemberInParty(location.getPartyId(), memberId);
+		location.checkAuthorization(memberId);
 	}
 }

--- a/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/LocationMapper.java
@@ -17,8 +17,9 @@ public class LocationMapper {
 		);
 	}
 
-	public static Location toLocation(LocationRegisterRequest locationRegisterRequest){
+	public static Location toLocation(LocationRegisterRequest locationRegisterRequest, Long memberId){
 		return Location.builder()
+				.memberId(memberId)
 				.name(locationRegisterRequest.name())
 				.searchAddress(locationRegisterRequest.searchAddress())
 				.address(locationRegisterRequest.address())

--- a/src/main/resources/db/migration/V14__alter_location_add_member_id.sql
+++ b/src/main/resources/db/migration/V14__alter_location_add_member_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `location`
+    ADD `member_id` BIGINT NOT NULL
+AFTER `id`;

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
@@ -109,6 +109,7 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 		location = locationRepository.save(
 				Location.builder()
 						.category(Category.COFFEE)
+						.memberId(member.getId())
 						.visitDate(LocalDateTime.now().plusDays(4))
 						.description("아인슈페너가 맛있는 곳!")
 						.name("cafe")

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/PartyRouteCommentControllerTest.java
@@ -117,6 +117,7 @@ public class PartyRouteCommentControllerTest {
 		location = locationRepository.save(
 				Location.builder()
 						.category(Category.COFFEE)
+						.memberId(member.getId())
 						.visitDate(LocalDateTime.now().plusDays(4))
 						.description("아인슈페너가 맛있는 곳!")
 						.name("cafe")

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
@@ -276,6 +276,7 @@ public class LocationCommentServiceTest {
 		return Location.builder()
 				.id(1L)
 				.image("httpL//.png")
+				.memberId(member.getId())
 				.category(Category.MEAL)
 				.description("딸기 뷔페!! 드디어 예약 성공!! Must Be StrawBerry!!!")
 				.address("서울특별시 중구 을지로 30 페닌슐라 라운지 & 바")

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
@@ -308,6 +308,7 @@ public class PartyRouteCommentServiceTest {
 	private Location getLocation() {
 		return Location.builder()
 				.id(1L)
+				.memberId(member.getId())
 				.partyId(party.getId())
 				.expectedCost(50000)
 				.spending(45000)

--- a/src/test/java/org/prgrms/wumo/domain/like/controller/RouteLikeControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/like/controller/RouteLikeControllerTest.java
@@ -85,6 +85,7 @@ class RouteLikeControllerTest extends MysqlTestContainer {
 		);
 		location = locationRepository.save(
 				Location.builder()
+						.memberId(member.getId())
 						.category(Category.STUDY)
 						.name("프로그래머스 대륭 서초 타워")
 						.description("그렙!!")

--- a/src/test/java/org/prgrms/wumo/domain/location/LocationTestUtils.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/LocationTestUtils.java
@@ -12,6 +12,7 @@ public class LocationTestUtils {
 
 	Location location1 = Location.builder()
 			.id(1L).image("http://programmers_gangnam_image.com")
+			.memberId(1L)
 			.description("이번에 새로 오픈한 프로그래머스 강남 교육장!! 모니터도 있고 좋은데 화장실이 좀....")
 			.latitude(latitude1).longitude(longitude1)
 			.address("강남역 2번출구").visitDate(dayToVisit)
@@ -23,6 +24,7 @@ public class LocationTestUtils {
 
 	Location location2 = Location.builder()
 			.id(2L).image("http://grepp_image")
+			.memberId(1L)
 			.description("그렙!!")
 			.latitude(latitude1).longitude(longitude1)
 			.address("서울특별시 서초구 강남대로327 2층 프로그래머스(서초동, 대륭서초타워)")
@@ -35,6 +37,7 @@ public class LocationTestUtils {
 
 	Location location3 = Location.builder()
 			.id(3L).image("http://gang_name_station_starbucks")
+			.memberId(1L)
 			.description("하태하태 강남역 스벅 강남 R점")
 			.latitude(latitude1).longitude(longitude1)
 			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
@@ -46,6 +49,7 @@ public class LocationTestUtils {
 
 	Location location4 = Location.builder()
 			.id(4L).image("http://four_image")
+			.memberId(1L)
 			.description("4번째 핫플")
 			.latitude(latitude1).longitude(longitude1)
 			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
@@ -57,6 +61,7 @@ public class LocationTestUtils {
 
 	Location location5 = Location.builder()
 			.id(5L).image("http://five_image.com")
+			.memberId(1L)
 			.description("5번 째 핫풀")
 			.latitude(latitude1).longitude(longitude1)
 			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
@@ -68,6 +73,7 @@ public class LocationTestUtils {
 
 	Location location6 = Location.builder()
 			.id(6L).image("http://six_image.com")
+			.memberId(1L)
 			.description("6번째 핫플")
 			.latitude(latitude1).longitude(longitude1)
 			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)
@@ -78,6 +84,7 @@ public class LocationTestUtils {
 			.build();
 	Location location7 = Location.builder()
 			.id(7L).image("http://seven_image")
+			.memberId(1L)
 			.description("7번째 핫플")
 			.latitude(latitude1).longitude(longitude1)
 			.address("서울 강남구 강남대로 30로").visitDate(dayToVisit)

--- a/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/api/LocationControllerTest.java
@@ -204,6 +204,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 		// Given
 		Location location = locationRepository.save(
 				Location.builder()
+						.memberId(member.getId())
 						.category(Category.COFFEE)
 						.visitDate(locationTestUtils.getDayToVisit())
 						.description("아인슈페너가 맛있는 곳!")
@@ -239,6 +240,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 		// Given
 		Long locationId = locationRepository.save(
 				Location.builder()
+						.memberId(member.getId())
 						.category(Category.COFFEE)
 						.visitDate(locationTestUtils.getDayToVisit())
 						.description("아인슈페너가 맛있는 곳!")
@@ -272,6 +274,7 @@ public class LocationControllerTest extends MysqlTestContainer {
 		// Given
 		Location location = locationRepository.save(
 				Location.builder()
+						.memberId(member.getId())
 						.category(Category.COFFEE)
 						.visitDate(locationTestUtils.getDayToVisit())
 						.description("아인슈페너가 맛있는 곳!")

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -229,6 +229,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 	private Location getLocationData() {
 		return Location.builder()
 			.name("오예스 찜닭")
+			.memberId(memberId)
 			.latitude(12.3456F)
 			.longitude(34.5678F)
 			.searchAddress("서귀포시")

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -329,6 +329,7 @@ public class RouteServiceTest {
 	private Location getLocationData() {
 		return Location.builder()
 			.id(locationId)
+			.memberId(1L)
 			.name("오예스 찜닭")
 			.latitude(12.3456F)
 			.longitude(34.5678F)
@@ -362,6 +363,7 @@ public class RouteServiceTest {
 	private Route getPublicRouteData2() {
 		Location location = Location.builder()
 			.id(2L)
+			.memberId(1L)
 			.name("오예스 치킨")
 			.latitude(23.3456F)
 			.longitude(45.5678F)


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

후보지 수정 및 삭제 권한 변경

### ⛏ 중점 사항

- 후보지 권한 확인을 위한 스키마 변경 (location 에 member_id 추가)
 - 이로 인한 Location 을 사용하는 테스트 코드에서 필드 추가
- 후보지 수정 및 삭제 권한
 - 기존 : 모임내 모든 인원 -> 변경 후 : 후보지 등록인 및 모임장
- 변경된 권한 테스트
### 💡 관련 이슈

- Resolved : WUMO-324, WUMO-325, WUMO-326, WUMO-327