### PR TITLE
[WUMO-330] Party 삭제 및 탈퇴 기능 리팩토링

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
@@ -86,8 +86,12 @@ public class ImageRepository {
 	}
 
 	private void validateHost(String imageUrl) {
-		if (!imageUrl.substring(0, imageUrl.indexOf("/")).equals(BUCKET_URL)) {
-			log.info("버킷에 저장되지 않은 이미지를 삭제 요청했습니다. ({})", imageUrl);
+		try {
+			if (!imageUrl.substring(0, imageUrl.indexOf("/")).equals(BUCKET_URL)) {
+				log.info("버킷에 저장되지 않은 이미지를 삭제 요청했습니다. ({})", imageUrl);
+			}
+		} catch (IndexOutOfBoundsException e) {
+			log.info("비정상적인 이미지 경로입니다. ({})", imageUrl);
 		}
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyControllerTest.java
@@ -205,7 +205,7 @@ class PartyControllerTest extends MysqlTestContainer {
 				LocalDate.now(),
 				LocalDate.now().plusDays(1),
 				"팀 설립 기념 워크샵",
-				"https://~.jpeg",
+				"https://~/test.png",
 				"총무"
 		);
 	}

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.image.repository.ImageRepository;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyGetRequest;
@@ -38,6 +39,7 @@ import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.prgrms.wumo.domain.party.repository.InvitationRepository;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.party.repository.PartyRepository;
+import org.prgrms.wumo.global.exception.custom.PartyNotEmptyException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -57,6 +59,9 @@ class PartyServiceTest {
 
 	@Mock
 	InvitationRepository invitationRepository;
+
+	@Mock
+	ImageRepository imageRepository;
 
 	@InjectMocks
 	PartyService partyService;
@@ -348,11 +353,13 @@ class PartyServiceTest {
 	class DeleteParty {
 
 		@Test
-		@DisplayName("식별자가 일치하는 모임을 삭제한다.")
+		@DisplayName("모임장 외 다른 회원이 없으면 모임을 삭제한다.")
 		void success() {
 			//mocking
 			given(partyMemberRepository.findByPartyIdAndIsLeader(party.getId()))
 					.willReturn(Optional.of(partyMember));
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 2))
+					.willReturn(List.of(partyMember));
 
 			//when
 			partyService.deleteParty(party.getId());
@@ -361,9 +368,32 @@ class PartyServiceTest {
 			then(partyMemberRepository)
 					.should()
 					.findByPartyIdAndIsLeader(party.getId());
+			then(imageRepository)
+					.should()
+					.delete(party.getCoverImage());
+			then(invitationRepository)
+					.should()
+					.deleteAllByParty(party);
+			then(partyMemberRepository)
+					.should()
+					.delete(partyMember);
 			then(partyRepository)
 					.should()
-					.delete(party);
+					.deleteById(party.getId());
+		}
+
+		@Test
+		@DisplayName("모임의 다른 회원이 존재하면 예외가 발생한다.")
+		void failedWithNotEmptyParty() {
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndIsLeader(party.getId()))
+					.willReturn(Optional.of(partyMember));
+			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 2))
+					.willReturn(List.of(partyMember, partyMember));
+
+			//when
+			//then
+			Assertions.assertThrows(PartyNotEmptyException.class, () -> partyService.deleteParty(party.getId()));
 		}
 
 		@Test


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Party 삭제 및 탈퇴 기능 리팩토링

### ⛏ 중점 사항

- Image 삭제시 경로에 문제가 있을 경우 log만 남기는 정도로 변경했습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-330]

[WUMO-330]: https://shoekream.atlassian.net/browse/WUMO-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ