### PR TITLE
[WUMO-321] 모임 조회 N*2 쿼리 성능 개선

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberCustomRepository.java
@@ -16,6 +16,10 @@ public interface PartyMemberCustomRepository {
 
 	List<PartyMember> findAllByMemberId(Long memberId, Long cursorId, int pageSize, PartyType partyType);
 
+	List<Long> countAllByPartyIdIn(List<Long> partyIds);
+
+	List<PartyMember> findAllByPartyIdInAndIsLeader(List<Long> partyIds);
+
 	boolean existsByPartyIdAndMemberId(Long partyId, Long memberId);
 
 }

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -70,11 +70,11 @@ class PartyServiceTest {
 	@BeforeEach
 	void setUp() {
 		member = Member.builder()
-			.id(1L)
-			.email("5yes@gmail.com")
-			.nickname("오예스오리지널")
-			.password("qwe12345")
-			.build();
+				.id(1L)
+				.email("5yes@gmail.com")
+				.nickname("오예스오리지널")
+				.password("qwe12345")
+				.build();
 
 		partyRegisterRequest = new PartyRegisterRequest(
 				"오예스 워크샵",
@@ -170,9 +170,9 @@ class PartyServiceTest {
 			//mocking
 			given(partyMemberRepository.findAllByMemberId(member.getId(), null, 1, PartyType.ALL))
 					.willReturn(List.of(partyMember));
-			given(partyMemberRepository.countAllByParty(party))
-					.willReturn(1L);
-			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 3))
+			given(partyMemberRepository.countAllByPartyIdIn(List.of(party.getId())))
+					.willReturn(List.of(1L));
+			given(partyMemberRepository.findAllByPartyIdInAndIsLeader(List.of(party.getId())))
 					.willReturn(List.of(partyMember));
 
 			//when
@@ -180,6 +180,7 @@ class PartyServiceTest {
 
 			//then
 			assertThat(partyGetAllResponse.party()).isNotEmpty();
+			assertThat(partyGetAllResponse.party().get(0).totalMembers()).isEqualTo(1L);
 			assertThat(partyGetAllResponse.party().get(0).members()).isNotEmpty();
 
 			then(partyMemberRepository)
@@ -187,10 +188,10 @@ class PartyServiceTest {
 					.findAllByMemberId(member.getId(), null, 1, PartyType.ALL);
 			then(partyMemberRepository)
 					.should()
-					.countAllByParty(party);
+					.countAllByPartyIdIn(List.of(party.getId()));
 			then(partyMemberRepository)
 					.should()
-					.findAllByPartyId(party.getId(), null, 3);
+					.findAllByPartyIdInAndIsLeader(List.of(party.getId()));
 		}
 
 		@Test
@@ -226,7 +227,7 @@ class PartyServiceTest {
 					.willReturn(Optional.of(party));
 			given(partyMemberRepository.countAllByParty(party))
 					.willReturn(1L);
-			given(partyMemberRepository.findAllByPartyId(party.getId(), null, 3))
+			given(partyMemberRepository.findAllByPartyIdInAndIsLeader(List.of(party.getId())))
 					.willReturn(List.of(partyMember));
 
 			//when
@@ -250,7 +251,7 @@ class PartyServiceTest {
 					.countAllByParty(party);
 			then(partyMemberRepository)
 					.should()
-					.findAllByPartyId(party.getId(), null, 3);
+					.findAllByPartyIdInAndIsLeader(List.of(party.getId()));
 		}
 
 		@Test


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- 모임 조회 N*2 쿼리 성능 개선

### ⛏ 중점 사항

- 기존 10개 목록 조회 기준 20개 이상의 쿼리가 발생했고 3번의 쿼리만 실행하도록 개선했습니다.
  - 모임 목록의 각 정보를 먼저 탐색
  - 각 목록의 총 구성원 수를 탐색
  - 각 목록의 리더를 탐색
- 구성원 미리보기 N명 가져오는 쿼리 복잡도가 높아 파티장만 가져오도록 정책을 변경했습니다.
- 추후 서비스 개선사항에 포함될 것 같습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-321]

[WUMO-321]: https://shoekream.atlassian.net/browse/WUMO-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ