### PR TITLE
[WUMO-332] PartyMember 상세 조회 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/api/PartyMemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/api/PartyMemberController.java
@@ -43,12 +43,20 @@ public class PartyMemberController {
 	}
 
 	@GetMapping("/{partyId}/members")
-	@Operation(summary = "모임 구성원 조회")
+	@Operation(summary = "모임 구성원 목록 조회")
 	public ResponseEntity<PartyMemberGetAllResponse> getAllPartyMembers(
 			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId,
 			@Valid PartyMemberGetRequest partyMemberGetRequest
 	) {
 		return ResponseEntity.ok(partyMemberService.getAllPartyMembers(partyId, partyMemberGetRequest));
+	}
+
+	@GetMapping("/{partyId}/members/me")
+	@Operation(summary = "모임 내 개인정보 조회")
+	public ResponseEntity<PartyMemberGetResponse> getPartyMember(
+			@PathVariable @Parameter(description = "모임 식별자", required = true) Long partyId
+	) {
+		return ResponseEntity.ok(partyMemberService.getPartyMember(partyId));
 	}
 
 	@PatchMapping("/{partyId}/members")

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
@@ -72,6 +72,11 @@ public class PartyMemberService {
 		return toPartyMemberGetAllResponse(totalMembers, partyMembers, lastId);
 	}
 
+	@Transactional(readOnly = true)
+	public PartyMemberGetResponse getPartyMember(Long partyId) {
+		return toPartyMemberGetResponse(getPartyMemberEntity(partyId, JwtUtil.getMemberId()));
+	}
+
 	@Transactional
 	public PartyMemberGetResponse updatePartyMember(Long partyId, PartyMemberUpdateRequest partyMemberUpdateRequest) {
 		PartyMember partyMember = getPartyMemberEntity(partyId, JwtUtil.getMemberId());

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
@@ -134,7 +134,7 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 	}
 
 	@Test
-	@DisplayName("특정 모임의 구성원을 조회할 수 있다.")
+	@DisplayName("특정 모임의 구성원 목록을 조회할 수 있다.")
 	void getAllPartyMembers() throws Exception {
 		//given
 		setAuthentication(leader.getId());
@@ -154,6 +154,25 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.members[0].role").value(partyLeader.getRole()))
 				.andExpect(jsonPath("$.members[0].profileImage").value(leader.getProfileImage()))
 				.andExpect(jsonPath("$.lastId").isNotEmpty())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("모임 내 자신의 정보를 조회할 수 있다.")
+	void getPartyMember() throws Exception {
+		//given
+		setAuthentication(leader.getId());
+
+		//when
+		ResultActions resultActions = mockMvc.perform(get("/api/v1/parties/{partyId}/members/me", party.getId()));
+
+		//then
+		resultActions
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.memberId").value(leader.getId()))
+				.andExpect(jsonPath("$.nickname").value(leader.getNickname()))
+				.andExpect(jsonPath("$.role").value(partyLeader.getRole()))
+				.andExpect(jsonPath("$.profileImage").value(leader.getProfileImage()))
 				.andDo(print());
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyMemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyMemberServiceTest.java
@@ -202,6 +202,48 @@ class PartyMemberServiceTest {
 	}
 
 	@Nested
+	@DisplayName("getPartyMember 메소드는 조회시")
+	class GetPartyMember {
+		//given
+		PartyMemberGetRequest partyMemberGetRequest = new PartyMemberGetRequest(null, 2);
+
+		@Test
+		@DisplayName("현재 모임의 구성원 목록을 반환한다.")
+		void success() {
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), participant.getId()))
+					.willReturn(Optional.of(partyParticipant));
+
+			//when
+			PartyMemberGetResponse partyMemberGetResponse = partyMemberService.getPartyMember(party.getId());
+
+			//then
+			assertThat(partyMemberGetResponse.memberId()).isEqualTo(participant.getId());
+			assertThat(partyMemberGetResponse.nickname()).isEqualTo(participant.getNickname());
+			assertThat(partyMemberGetResponse.role()).isEqualTo(partyParticipant.getRole());
+			assertThat(partyMemberGetResponse.profileImage()).isEqualTo(participant.getProfileImage());
+
+			then(partyMemberRepository)
+					.should()
+					.findByPartyIdAndMemberId(party.getId(), participant.getId());
+		}
+
+		@Test
+		@DisplayName("모임의 구성원이 아니라면 예외가 발생한다.")
+		void failed() {
+			//mocking
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), participant.getId()))
+					.willReturn(Optional.empty());
+
+			//when
+			//then
+			Assertions.assertThrows(EntityNotFoundException.class,
+					() -> partyMemberService.getPartyMember(party.getId()));
+		}
+
+	}
+
+	@Nested
 	@DisplayName("updatePartyMember 메소드는 수정시")
 	class UpdatePartyMember {
 		//given


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- 모임 내 회원의 상세 정보 조회 기능 구현 및 테스트

### ⛏ 중점 사항

- 모임 내 회원의 역할 변경 전 해당 회원의 모임 내 정보를 조회해야하는 요구사항에 따른 기능 추가

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-333], [WUMO-334]

[WUMO-333]: https://shoekream.atlassian.net/browse/WUMO-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-334]: https://shoekream.atlassian.net/browse/WUMO-334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ