### PR TITLE
[WUMO-335] Member 내 정보 조회 기능 리팩토링

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
@@ -18,7 +18,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -107,12 +106,11 @@ public class MemberController {
 		return ResponseEntity.ok(memberService.reissueMember(memberReissueRequest));
 	}
 
-	@GetMapping("/{memberId}")
+	@GetMapping
 	@Operation(summary = "내 정보 조회")
-	public ResponseEntity<MemberGetResponse> getMember(
-		@PathVariable @Parameter(description = "조회할 회원 아이디") long memberId) {
+	public ResponseEntity<MemberGetResponse> getMember() {
 
-		return ResponseEntity.ok(memberService.getMember(memberId));
+		return ResponseEntity.ok(memberService.getMember());
 	}
 
 	@PatchMapping

--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -24,6 +24,7 @@ import org.prgrms.wumo.global.exception.custom.DuplicateException;
 import org.prgrms.wumo.global.exception.custom.InvalidCodeException;
 import org.prgrms.wumo.global.exception.custom.InvalidRefreshTokenException;
 import org.prgrms.wumo.global.jwt.JwtTokenProvider;
+import org.prgrms.wumo.global.jwt.JwtUtil;
 import org.prgrms.wumo.global.jwt.WumoJwt;
 import org.prgrms.wumo.global.repository.RedisRepository;
 import org.prgrms.wumo.global.sender.Sender;
@@ -120,9 +121,8 @@ public class MemberService {
 	}
 
 	@Transactional(readOnly = true)
-	public MemberGetResponse getMember(long memberId) {
-		validateAccess(memberId);
-		return toMemberGetResponse(getMemberEntity(memberId));
+	public MemberGetResponse getMember() {
+		return toMemberGetResponse(getMemberEntity(JwtUtil.getMemberId()));
 	}
 
 	@Transactional

--- a/src/main/java/org/prgrms/wumo/global/config/WebConfig.java
+++ b/src/main/java/org/prgrms/wumo/global/config/WebConfig.java
@@ -3,11 +3,9 @@ package org.prgrms.wumo.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@EnableWebMvc
 public class WebConfig implements WebMvcConfigurer {
 
 	@Value("${front.server}")

--- a/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
@@ -116,34 +116,12 @@ public class MemberControllerTest extends MysqlTestContainer {
 			.andExpect(status().isNoContent());
 	}
 
-	// @Test
-	// @DisplayName("로그인을 한다")
-	// void login_member() throws Exception {
-	// 	//given
-	// 	MemberLoginRequest memberLoginRequest
-	// 		= new MemberLoginRequest("taehee@gmail.com", "qwe12345");
-	//
-	// 	//when
-	// 	ResultActions resultActions
-	// 		= mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/members/login")
-	// 		.contentType(MediaType.APPLICATION_JSON_VALUE)
-	// 		.content(objectMapper.writeValueAsString(memberLoginRequest)));
-	//
-	// 	//then
-	// 	resultActions
-	// 		.andExpect(status().isOk())
-	// 		.andExpect(jsonPath("$.grantType").isNotEmpty())
-	// 		.andExpect(jsonPath("$.accessToken").isNotEmpty())
-	// 		.andExpect(jsonPath("$.refreshToken").isNotEmpty())
-	// 		.andDo(print());
-	// }
-
 	@Test
 	@DisplayName("내 정보를 조회한다")
 	void get_member() throws Exception {
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/{memberId}", memberId));
+			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members"));
 
 		//then
 		resultActions

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -38,7 +38,6 @@ import org.prgrms.wumo.global.jwt.JwtTokenProvider;
 import org.prgrms.wumo.global.jwt.WumoJwt;
 import org.prgrms.wumo.global.repository.RedisRepository;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
@@ -238,29 +237,20 @@ public class MemberServiceTest {
 		Member member = getMemberData(email, nickname, password);
 
 		@Test
-		@DisplayName("내 정보 요청이면 응답한다")
+		@DisplayName("내 정보를 응답한다")
 		void success() {
 			//mocking
 			given(memberRepository.findById(anyLong()))
 				.willReturn(Optional.of(member));
 
 			//when
-			MemberGetResponse result = memberService.getMember(memberId);
+			MemberGetResponse result = memberService.getMember();
 
 			//then
 			assertThat(result.nickname()).isEqualTo(member.getNickname());
 			then(memberRepository)
 				.should()
 				.findById(anyLong());
-		}
-
-		@Test
-		@DisplayName("다른 유저의 정보 요청이면 예외가 발생한다")
-		void fail_not_me() {
-			//when, then
-			assertThatThrownBy(() -> memberService.getMember(2L))
-				.isInstanceOf(AccessDeniedException.class)
-				.hasMessage("잘못된 접근입니다.");
 		}
 	}
 


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 내 정보 조회 기능에서 client에서 memberId를 받아오지 않고  
서버쪽에서 현재 로그인한 유저의 정보를 보내주는 것으로 변경했습니다  

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 특이사항은 없습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-336], [WUMO-337]

[WUMO-336]: https://shoekream.atlassian.net/browse/WUMO-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-337]: https://shoekream.atlassian.net/browse/WUMO-337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ