### PR TITLE
[WUMO-322] Route 관심 루트 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepository.java
@@ -1,8 +1,14 @@
 package org.prgrms.wumo.domain.like.repository;
 
+import java.util.List;
 import java.util.Map;
 
+import org.prgrms.wumo.domain.route.model.Route;
+import org.springframework.data.util.Pair;
+
 public interface RouteLikeCustomRepository {
+
+	Pair<List<Long>, List<Route>> findAllByMemberId(Long memberId, Long cursorId, int pageSize);
 
 	Map<Long, Long> countAllByRouteId(Long cursorId, int batchSize);
 

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
@@ -3,15 +3,9 @@ package org.prgrms.wumo.domain.party.repository;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long>, PartyMemberCustomRepository {
 
 	long countAllByParty(Party party);
-
-	@Modifying(clearAutomatically = true)
-	@Query("DELETE FROM PartyMember pm WHERE pm.party = :party")
-	void deleteAllByParty(Party party);
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
@@ -58,6 +58,14 @@ public class RouteController {
 		return ResponseEntity.ok(routeService.getAllRoute(routeGetAllRequest));
 	}
 
+	@GetMapping("/likes")
+	@Operation(summary = "관심 루트 목록 조회")
+	public ResponseEntity<RouteGetAllResponses> getAllLikedRoute(
+			@Valid RouteGetAllRequest routeGetAllRequest) {
+
+		return ResponseEntity.ok(routeService.getAllLikedRoute(routeGetAllRequest));
+	}
+
 	@PatchMapping
 	@Operation(summary = "루트 공개여부 변경")
 	public ResponseEntity<Void> updateRoutePublicStatus(

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -24,6 +24,7 @@ import org.prgrms.wumo.domain.route.dto.response.RouteGetResponse;
 import org.prgrms.wumo.domain.route.dto.response.RouteRegisterResponse;
 import org.prgrms.wumo.domain.route.model.Route;
 import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.springframework.data.util.Pair;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -86,6 +87,25 @@ public class RouteService {
 		long lastId = -1L;
 		if (routes.size() != 0) {
 			lastId = routes.get(routes.size() - 1).getId();
+		}
+
+		return toRouteGetAllResponses(routes, lastId);
+	}
+
+	@Transactional(readOnly = true)
+	public RouteGetAllResponses getAllLikedRoute(RouteGetAllRequest routeGetAllRequest) {
+		Pair<List<Long>, List<Route>> pair = routeLikeRepository.findAllByMemberId(
+				getMemberId(),
+				routeGetAllRequest.cursorId(),
+				routeGetAllRequest.pageSize());
+
+		List<Route> routes = pair.getSecond();
+		addIsLiking(routes);
+
+		long lastId = -1L;
+		List<Long> routeLikeIds = pair.getFirst();
+		if (routeLikeIds.size() != 0) {
+			lastId = routeLikeIds.get(routeLikeIds.size() - 1);
 		}
 
 		return toRouteGetAllResponses(routes, lastId);

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -220,7 +220,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 		//then
 		resultActions
 				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.lastId").value(routeId))
+				.andExpect(jsonPath("$.lastId").value(routeLikeId))
 				.andExpect(jsonPath("$.routes").isArray())
 				.andExpect(jsonPath("$.routes[0].routeId").value(routeId))
 				.andDo(print());


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Route 관심 루트 목록 조회 기능 구현 및 테스트

### ⛏ 중점 사항

- Pair를 사용해서 RouteLike 기준으로 Cursor ID를 뱉도록 구현했습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-347], [WUMO-348]

[WUMO-347]: https://shoekream.atlassian.net/browse/WUMO-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-348]: https://shoekream.atlassian.net/browse/WUMO-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ