### PR TITLE
[WUMO-349] PartyMember 조회 시 isLeader 필드 추가

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyMemberGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/response/PartyMemberGetResponse.java
@@ -15,7 +15,10 @@ public record PartyMemberGetResponse(
 		String role,
 
 		@Schema(description = "프로필 이미지", example = "https://~.jpeg", requiredMode = Schema.RequiredMode.REQUIRED)
-		String profileImage
+		String profileImage,
+
+		@Schema(description = "모임장 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+		boolean isLeader
 
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -3,6 +3,7 @@ package org.prgrms.wumo.domain.party.service;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toParty;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetAllResponse;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetDetailResponse;
+import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyMember;
 import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyRegisterResponse;
 
 import java.time.LocalDateTime;
@@ -56,12 +57,7 @@ public class PartyService {
 
 		// 모임장 저장
 		Member member = getMemberEntity(JwtUtil.getMemberId());
-		PartyMember partyLeader = PartyMember.builder()
-				.member(member)
-				.party(party)
-				.role(partyRegisterRequest.role())
-				.isLeader(true)
-				.build();
+		PartyMember partyLeader = toPartyMember(member, party, partyRegisterRequest.role(), true);
 		partyMemberRepository.save(partyLeader);
 
 		return toPartyRegisterResponse(party);

--- a/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/PartyMapper.java
@@ -76,7 +76,7 @@ public class PartyMapper {
 				.member(member)
 				.party(party)
 				.role(role)
-				.isLeader(false)
+				.isLeader(isLeader)
 				.build();
 	}
 
@@ -92,7 +92,8 @@ public class PartyMapper {
 				partyMember.getMember().getId(),
 				partyMember.getMember().getNickname(),
 				partyMember.getRole(),
-				partyMember.getMember().getProfileImage()
+				partyMember.getMember().getProfileImage(),
+				partyMember.isLeader()
 		);
 	}
 

--- a/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/api/PartyMemberControllerTest.java
@@ -66,8 +66,6 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 
 	private PartyMember partyLeader;
 
-	private PartyMember partyParticipant;
-
 	@BeforeEach
 	void setup() {
 		leader = memberRepository.save(
@@ -153,6 +151,7 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.members[0].nickname").value(leader.getNickname()))
 				.andExpect(jsonPath("$.members[0].role").value(partyLeader.getRole()))
 				.andExpect(jsonPath("$.members[0].profileImage").value(leader.getProfileImage()))
+				.andExpect(jsonPath("$.members[0].isLeader").value(partyLeader.isLeader()))
 				.andExpect(jsonPath("$.lastId").isNotEmpty())
 				.andDo(print());
 	}
@@ -173,6 +172,7 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 				.andExpect(jsonPath("$.nickname").value(leader.getNickname()))
 				.andExpect(jsonPath("$.role").value(partyLeader.getRole()))
 				.andExpect(jsonPath("$.profileImage").value(leader.getProfileImage()))
+				.andExpect(jsonPath("$.isLeader").value(partyLeader.isLeader()))
 				.andDo(print());
 	}
 
@@ -202,13 +202,7 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 	@DisplayName("모임 생성자는 구성원을 추방할 수 있다.")
 	void deletePartyMemberWithLeader() throws Exception {
 		//given
-		partyParticipant = partyMemberRepository.save(
-				PartyMember.builder()
-						.member(participant)
-						.party(party)
-						.role("요리사")
-						.build()
-		);
+		partyMemberRepository.save(getPartyParticipant());
 		setAuthentication(leader.getId());
 
 		//when
@@ -224,13 +218,7 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 	@DisplayName("모임에서 탈퇴할 수 있다.")
 	void deletePartyMember() throws Exception {
 		//given
-		partyParticipant = partyMemberRepository.save(
-				PartyMember.builder()
-						.member(participant)
-						.party(party)
-						.role("요리사")
-						.build()
-		);
+		partyMemberRepository.save(getPartyParticipant());
 
 		//when
 		ResultActions resultActions = mockMvc.perform(delete("/api/v1/parties/{partyId}/members", party.getId()));
@@ -251,8 +239,18 @@ class PartyMemberControllerTest extends MysqlTestContainer {
 	private PartyMemberRegisterRequest getPartyMemberRegisterRequest() {
 		return new PartyMemberRegisterRequest("운전기사");
 	}
+
 	private PartyMemberUpdateRequest getPartyMemberUpdateRequest() {
 		return new PartyMemberUpdateRequest("드라이버");
+	}
+
+	private PartyMember getPartyParticipant() {
+		return PartyMember.builder()
+				.member(participant)
+				.party(party)
+				.role("요리사")
+				.isLeader(false)
+				.build();
 	}
 
 }

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyMemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyMemberServiceTest.java
@@ -204,9 +204,6 @@ class PartyMemberServiceTest {
 	@Nested
 	@DisplayName("getPartyMember 메소드는 조회시")
 	class GetPartyMember {
-		//given
-		PartyMemberGetRequest partyMemberGetRequest = new PartyMemberGetRequest(null, 2);
-
 		@Test
 		@DisplayName("현재 모임의 구성원 목록을 반환한다.")
 		void success() {
@@ -222,6 +219,7 @@ class PartyMemberServiceTest {
 			assertThat(partyMemberGetResponse.nickname()).isEqualTo(participant.getNickname());
 			assertThat(partyMemberGetResponse.role()).isEqualTo(partyParticipant.getRole());
 			assertThat(partyMemberGetResponse.profileImage()).isEqualTo(participant.getProfileImage());
+			assertThat(partyMemberGetResponse.isLeader()).isEqualTo(false);
 
 			then(partyMemberRepository)
 					.should()


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- PartyMember 조회 시 isLeader 필드 추가

### ⛏ 중점 사항

- 자신의 권한을 확인할 수 있도록 프론트엔드 요구사항 반영

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-349]

[WUMO-349]: https://shoekream.atlassian.net/browse/WUMO-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ