### PR TITLE
[WUMO-354] Comment 상세 조회 응답 DTO isEditable 필드 추가

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/LocationCommentGetResponse.java
@@ -28,6 +28,9 @@ public record LocationCommentGetResponse(
 		LocalDateTime createdAt,
 
 		@Schema(description = "댓글 수정 시간", example = "2023-03-03T14:03:23", requiredMode = Schema.RequiredMode.REQUIRED)
-		LocalDateTime updatedAt
+		LocalDateTime updatedAt,
+
+		@Schema(description = "댓글 수정 및 삭제 가능 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+		boolean isEditable
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/PartyRouteCommentGetResponse.java
@@ -28,6 +28,9 @@ public record PartyRouteCommentGetResponse(
 		LocalDateTime createdAt,
 
 		@Schema(description = "댓글 수정 시간", example = "2023-03-03T14:03:23", requiredMode = Schema.RequiredMode.REQUIRED)
-		LocalDateTime updatedAt
+		LocalDateTime updatedAt,
+
+		@Schema(description = "댓글 수정 및 삭제 가능 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+		boolean isEditable
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
@@ -7,6 +7,7 @@ import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationCommentRegis
 import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationCommentUpdateResponse;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -55,10 +56,14 @@ public class LocationCommentService {
 				locationCommentRepository.findAllByLocationId(locationCommentGetAllRequest.locationId(),
 						locationCommentGetAllRequest.cursorId(), locationCommentGetAllRequest.pageSize());
 
+		List<Boolean> isEditables = locationComments.stream()
+				.map(locationComment -> getIsEditable(locationComment, getMemberId()))
+				.toList();
+
 		long lastId = (locationComments.size()) > 0 ?
 				locationComments.get(locationComments.size() - 1).getId() : -1L;
 
-		return toLocationCommentGetAllResponse(locationComments, lastId);
+		return toLocationCommentGetAllResponse(locationComments, isEditables, lastId);
 	}
 
 	@Transactional
@@ -101,6 +106,10 @@ public class LocationCommentService {
 	private void checkAuthorization(LocationComment locationComment, Long memberId) {
 		checkMemberInParty(locationComment.getPartyMember().getId());
 		locationComment.checkAuthorization(memberId);
+	}
+
+	private boolean getIsEditable(LocationComment locationComment, Long memberId) {
+		return Objects.equals(locationComment.getMember().getId(), memberId);
 	}
 }
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
@@ -7,6 +7,7 @@ import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentReg
 import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentUpdateResponse;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -62,10 +63,14 @@ public class PartyRouteCommentService {
 				partyRouteCommentRepository.findAllByLocationId(partyRouteCommentGetAllRequest.cursorId(),
 						partyRouteCommentGetAllRequest.pageSize(), partyRouteCommentGetAllRequest.locationId());
 
+		List<Boolean> isEditables = partyRouteComments.stream()
+				.map(partyRouteComment -> getIsEditable(partyRouteComment, getMemberId()))
+				.toList();
+
 		long lastId = (partyRouteComments.size()) > 0 ?
 				partyRouteComments.get(partyRouteComments.size() - 1).getId() : -1L;
 
-		return toPartyRouteCommentGetAllResponse(partyRouteComments, lastId);
+		return toPartyRouteCommentGetAllResponse(partyRouteComments, isEditables, lastId);
 	}
 
 	@Transactional
@@ -113,6 +118,10 @@ public class PartyRouteCommentService {
 	private void checkAuthorization(PartyRouteComment partyRouteComment, Long memberId) {
 		checkMemberInParty(partyRouteComment.getPartyMember().getId());
 		partyRouteComment.checkAuthorization(memberId);
+	}
+
+	private boolean getIsEditable(PartyRouteComment partyRouteComment, Long memberId) {
+		return Objects.equals(partyRouteComment.getMember().getId(), memberId);
 	}
 }
 

--- a/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
@@ -1,5 +1,6 @@
 package org.prgrms.wumo.global.mapper;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentRegisterRequest;
@@ -23,7 +24,8 @@ public class CommentMapper {
 		);
 	}
 
-	public static LocationComment toLocationComment(LocationCommentRegisterRequest locationCommentRegisterRequest, PartyMember partyMember) {
+	public static LocationComment toLocationComment(LocationCommentRegisterRequest locationCommentRegisterRequest,
+			PartyMember partyMember) {
 		return LocationComment.builder()
 				.locationId(locationCommentRegisterRequest.locationId())
 				.content(locationCommentRegisterRequest.content())
@@ -32,7 +34,8 @@ public class CommentMapper {
 				.build();
 	}
 
-	public static LocationCommentGetResponse toLocationCommentGetResponse(LocationComment locationComment) {
+	public static LocationCommentGetResponse toLocationCommentGetResponse(LocationComment locationComment,
+			boolean isEditable) {
 		return new LocationCommentGetResponse(
 				locationComment.getId(),
 				locationComment.getMember().getNickname(),
@@ -41,15 +44,22 @@ public class CommentMapper {
 				locationComment.getContent(),
 				locationComment.getImage(),
 				locationComment.getCreatedAt(),
-				locationComment.getUpdatedAt()
+				locationComment.getUpdatedAt(),
+				isEditable
 		);
 	}
 
 	public static LocationCommentGetAllResponse toLocationCommentGetAllResponse(
-			List<LocationComment> locationComments, Long lastId
+			List<LocationComment> locationComments, List<Boolean> isEditables, Long lastId
 	) {
+
+		List<LocationCommentGetResponse> locationCommentGetResponses = new ArrayList<>();
+		for (int i = 0; i < locationComments.size(); i++) {
+			locationCommentGetResponses.add(toLocationCommentGetResponse(locationComments.get(i), isEditables.get(i)));
+		}
+
 		return new LocationCommentGetAllResponse(
-				locationComments.stream().map(CommentMapper::toLocationCommentGetResponse).toList(),
+				locationCommentGetResponses,
 				lastId
 		);
 	}
@@ -79,7 +89,8 @@ public class CommentMapper {
 				.build();
 	}
 
-	public static PartyRouteCommentGetResponse toPartyRouteCommentGetResponse(PartyRouteComment partyRouteComment) {
+	public static PartyRouteCommentGetResponse toPartyRouteCommentGetResponse(PartyRouteComment partyRouteComment,
+			boolean isEditable) {
 		return new PartyRouteCommentGetResponse(
 				partyRouteComment.getId(),
 				partyRouteComment.getMember().getNickname(),
@@ -88,14 +99,19 @@ public class CommentMapper {
 				partyRouteComment.getContent(),
 				partyRouteComment.getImage(),
 				partyRouteComment.getCreatedAt(),
-				partyRouteComment.getUpdatedAt()
+				partyRouteComment.getUpdatedAt(),
+				isEditable
 		);
 	}
 
 	public static PartyRouteCommentGetAllResponse toPartyRouteCommentGetAllResponse(
-			List<PartyRouteComment> partyRouteComments, long lastId) {
+			List<PartyRouteComment> partyRouteComments, List<Boolean> isEditables, long lastId) {
+		List<PartyRouteCommentGetResponse> partyRouteCommentGetResponses = new ArrayList<>();
+		for (int i = 0; i < partyRouteComments.size(); i++) {
+			partyRouteCommentGetResponses.add(toPartyRouteCommentGetResponse(partyRouteComments.get(i), isEditables.get(i)));
+		}
 		return new PartyRouteCommentGetAllResponse(
-				partyRouteComments.stream().map(CommentMapper::toPartyRouteCommentGetResponse).toList(),
+				partyRouteCommentGetResponses,
 				lastId
 		);
 	}

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
@@ -134,11 +134,12 @@ public class LocationCommentServiceTest {
 					.build();
 
 			List<LocationComment> locationComments = List.of(locationComment2, locationComment3);
+			List<Boolean> isEditables = List.of(true, true);
 
 			LocationCommentGetAllRequest locationCommentGetAllRequest =
 					new LocationCommentGetAllRequest(null, 2, 2L);
 
-			LocationCommentGetAllResponse expected = toLocationCommentGetAllResponse(locationComments, 3L);
+			LocationCommentGetAllResponse expected = toLocationCommentGetAllResponse(locationComments, isEditables, 3L);
 
 			given(locationCommentRepository.findAllByLocationId(2L, null, 2))
 					.willReturn(locationComments);

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
@@ -145,9 +145,11 @@ public class PartyRouteCommentServiceTest {
 					.member(member)
 					.build();
 
+			List<Boolean> isEditables = List.of(true, true);
+
 			List<PartyRouteComment> partyRouteComments = List.of(partyRouteComment2, partyRouteComment3);
 			PartyRouteCommentGetAllRequest request = new PartyRouteCommentGetAllRequest(null, 2, 2L);
-			PartyRouteCommentGetAllResponse expected = toPartyRouteCommentGetAllResponse(partyRouteComments, 3L);
+			PartyRouteCommentGetAllResponse expected = toPartyRouteCommentGetAllResponse(partyRouteComments, isEditables, 3L);
 
 			// When
 			given(partyRouteCommentRepository.findAllByLocationId(null, 2, 2L))


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

후보지 댓글, 모임 내 루트 댓글 상세 조회 dto 에 isEditable 필드 추가

### ⛏ 중점 사항

댓글을 수정 및 삭제할 수 있는지 확인할 수 있는 필드 isEditable 필드가 추가되었습니다.
후보지와 달리 댓글은 작성자만 수정, 삭제가 가능합니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-355], [WUMO-356], [WUMO-357]

[WUMO-355]: https://shoekream.atlassian.net/browse/WUMO-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-356]: https://shoekream.atlassian.net/browse/WUMO-356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-357]: https://shoekream.atlassian.net/browse/WUMO-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ