### PR TITLE
[WUMO-370] Party 상세조회 권한 검증 기능 추가 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -84,10 +84,10 @@ public class PartyService {
 
 	@Transactional(readOnly = true)
 	public PartyGetResponse getParty(Long partyId) {
-		Party party = getPartyEntity(partyId);
-		setPartyDetail(party);
+		PartyMember partyMember = getPartyMemberEntity(partyId, JwtUtil.getMemberId());
+		setPartyDetail(partyMember.getParty());
 
-		return toPartyGetDetailResponse(party);
+		return toPartyGetDetailResponse(partyMember.getParty());
 	}
 
 	@Transactional
@@ -130,14 +130,14 @@ public class PartyService {
 				.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
 	}
 
-	private Party getPartyEntity(Long partyId) {
-		return partyRepository.findById(partyId)
-				.orElseThrow(() -> new EntityNotFoundException("일치하는 모임이 없습니다."));
-	}
-
 	private PartyMember getPartyLeaderEntity(Long partyId) {
 		return partyMemberRepository.findByPartyIdAndIsLeader(partyId)
 				.orElseThrow(() -> new EntityNotFoundException("일치하는 모임이 없습니다."));
+	}
+
+	private PartyMember getPartyMemberEntity(Long partyId, Long memberId) {
+		return partyMemberRepository.findByPartyIdAndMemberId(partyId, memberId)
+				.orElseThrow(() -> new EntityNotFoundException("해당 모임에 가입된 회원이 아닙니다."));
 	}
 
 	private void checkAuthorization(PartyMember partyMember) {

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -228,8 +228,8 @@ class PartyServiceTest {
 		@DisplayName("모임의 상세 정보를 반환한다.")
 		void success() {
 			//mocking
-			given(partyRepository.findById(party.getId()))
-					.willReturn(Optional.of(party));
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), member.getId()))
+					.willReturn(Optional.of(partyMember));
 			given(partyMemberRepository.countAllByParty(party))
 					.willReturn(1L);
 			given(partyMemberRepository.findAllByPartyIdInAndIsLeader(List.of(party.getId())))
@@ -248,9 +248,9 @@ class PartyServiceTest {
 			assertThat(myParty.totalMembers()).isEqualTo(1L);
 			assertThat(myParty.members()).isNotEmpty();
 
-			then(partyRepository)
+			then(partyMemberRepository)
 					.should()
-					.findById(party.getId());
+					.findByPartyIdAndMemberId(party.getId(), member.getId());
 			then(partyMemberRepository)
 					.should()
 					.countAllByParty(party);
@@ -260,10 +260,10 @@ class PartyServiceTest {
 		}
 
 		@Test
-		@DisplayName("존재하지 않는 모임이면 예외가 발생한다.")
+		@DisplayName("모임 구성원이 아니라면 예외가 발생한다.")
 		void failed() {
 			//mocking
-			given(partyRepository.findById(party.getId()))
+			given(partyMemberRepository.findByPartyIdAndMemberId(party.getId(), member.getId()))
 					.willReturn(Optional.empty());
 
 			//when


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Party 상세조회 권한 검증 기능 추가 구현 및 테스트

### ⛏ 중점 사항

- 특이사항 없음

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-39], [WUMO-371], [WUMO-371]

[WUMO-39]: https://shoekream.atlassian.net/browse/WUMO-39?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-371]: https://shoekream.atlassian.net/browse/WUMO-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-371]: https://shoekream.atlassian.net/browse/WUMO-371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ