### PR TITLE
[WUMO-94] ReplyComment 엔티티 추가 및  등록 기능 구현

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/api/LocationCommentController.java
@@ -3,15 +3,21 @@ package org.prgrms.wumo.domain.comment.api;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import javax.validation.Valid;
+
 import lombok.RequiredArgsConstructor;
+
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentGetAllRequest;
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentUpdateRequest;
+import org.prgrms.wumo.domain.comment.dto.request.ReplyCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentRegisterResponse;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentUpdateResponse;
+import org.prgrms.wumo.domain.comment.dto.response.ReplyCommentRegisterResponse;
 import org.prgrms.wumo.domain.comment.service.LocationCommentService;
+import org.prgrms.wumo.domain.comment.service.ReplyCommentService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -29,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "후보지 댓글 api")
 public class LocationCommentController {
 	private final LocationCommentService locationCommentService;
+	private final ReplyCommentService replyCommentService;
 
 	@PostMapping
 	@Operation(summary = "후보지 댓글 등록")
@@ -63,5 +70,14 @@ public class LocationCommentController {
 
 		locationCommentService.deleteLocationComment(locationCommentId);
 		return ResponseEntity.ok().build();
+	}
+
+	@PostMapping("/replies")
+	@Operation(summary = "후보지 댓글에 대댓글 작성")
+	public ResponseEntity<ReplyCommentRegisterResponse> registerReplyComment(
+			@RequestBody @Valid ReplyCommentRegisterRequest replyCommentRegisterRequest
+	) {
+		return new ResponseEntity<>(replyCommentService.registerReplyComment(replyCommentRegisterRequest),
+				HttpStatus.CREATED);
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/request/ReplyCommentRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/request/ReplyCommentRegisterRequest.java
@@ -1,0 +1,19 @@
+package org.prgrms.wumo.domain.comment.dto.request;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "대댓글 등록 요청 정보")
+public record ReplyCommentRegisterRequest(
+
+		@NotNull(message = "대댓글을 다는 댓글의 식별자는 필수 입력값입니다.")
+		@Schema(description = "대댓글이 작성된 댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long commentId,
+
+		@NotBlank(message = "대댓글은 내용이 빌 수 없습니다.")
+		@Schema(description = "대댓글 내용", example = "댓글 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+		String content
+) {
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/dto/response/ReplyCommentRegisterResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/dto/response/ReplyCommentRegisterResponse.java
@@ -1,0 +1,11 @@
+package org.prgrms.wumo.domain.comment.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(name = "대댓글 등록 응답 정보")
+public record ReplyCommentRegisterResponse(
+
+		@Schema(description = "작성된 대댓글 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long id
+) {
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/model/ReplyComment.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/model/ReplyComment.java
@@ -1,0 +1,60 @@
+package org.prgrms.wumo.domain.comment.model;
+
+import static lombok.AccessLevel.PROTECTED;
+
+import java.util.Objects;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.global.audit.BaseTimeEntity;
+import org.springframework.security.access.AccessDeniedException;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "reply_comment")
+@NoArgsConstructor(access = PROTECTED)
+public class ReplyComment extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	protected Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@Column(name = "comment_id", nullable = false, unique = false, updatable = false)
+	private Long commentId;
+
+	@Column(name = "content", nullable = false, unique = false, updatable = true, length = 255)
+	private String content;
+
+	@Builder
+	public ReplyComment(Long id, Member member, Long commentId, String content) {
+		this.id = id;
+		this.member = member;
+		this.commentId = commentId;
+		this.content = content;
+	}
+
+	public void setMember(Member member) {
+		this.member = member;
+	}
+
+	public void checkAuthorization(Long memberId) {
+		if (!Objects.equals(this.member.getId(), memberId)) {
+			throw new AccessDeniedException("대댓글은 작성자만 수정 및 삭제가 가능합니다.");
+		}
+	}
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/repository/ReplyCommentRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/repository/ReplyCommentRepository.java
@@ -1,0 +1,9 @@
+package org.prgrms.wumo.domain.comment.repository;
+
+import org.prgrms.wumo.domain.comment.model.ReplyComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long> {
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/ReplyCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/ReplyCommentService.java
@@ -1,0 +1,45 @@
+package org.prgrms.wumo.domain.comment.service;
+
+import static org.prgrms.wumo.global.mapper.CommentMapper.toReplyComment;
+import static org.prgrms.wumo.global.mapper.CommentMapper.toReplyCommentRegisterResponse;
+
+import javax.persistence.EntityNotFoundException;
+
+import org.prgrms.wumo.domain.comment.dto.request.ReplyCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.response.ReplyCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.model.LocationComment;
+import org.prgrms.wumo.domain.comment.model.ReplyComment;
+import org.prgrms.wumo.domain.comment.repository.LocationCommentRepository;
+import org.prgrms.wumo.domain.comment.repository.ReplyCommentRepository;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReplyCommentService {
+	private final ReplyCommentRepository replyCommentRepository;
+	private final LocationCommentRepository locationCommentRepository;
+	private final PartyMemberRepository partyMemberRepository;
+
+	@Transactional
+	public ReplyCommentRegisterResponse registerReplyComment(ReplyCommentRegisterRequest replyCommentRegisterRequest){
+		LocationComment locationComment = getLocationCommentEntity(replyCommentRegisterRequest.commentId());
+		checkMemberInParty(locationComment.getPartyMember().getId());
+		ReplyComment replyComment = toReplyComment(replyCommentRegisterRequest, locationComment.getMember());
+		return toReplyCommentRegisterResponse(replyCommentRepository.save(replyComment));
+	}
+
+	private LocationComment getLocationCommentEntity(Long locationCommentId){
+		return locationCommentRepository.findById(locationCommentId)
+				.orElseThrow(() -> new EntityNotFoundException("댓글을 작성하고자 하는 후보지 댓글이 존재하지 않습니다."));
+	}
+
+	private void checkMemberInParty(Long partyMemberId){
+		if (!partyMemberRepository.existsById(partyMemberId))
+			throw new AccessDeniedException("모임 내 회원이 아닙니다.");
+	}
+}

--- a/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/CommentMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.request.PartyRouteCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.request.ReplyCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentGetAllResponse;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentGetResponse;
 import org.prgrms.wumo.domain.comment.dto.response.LocationCommentRegisterResponse;
@@ -13,8 +14,11 @@ import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetAllRespon
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentGetResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentRegisterResponse;
 import org.prgrms.wumo.domain.comment.dto.response.PartyRouteCommentUpdateResponse;
+import org.prgrms.wumo.domain.comment.dto.response.ReplyCommentRegisterResponse;
 import org.prgrms.wumo.domain.comment.model.LocationComment;
 import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
+import org.prgrms.wumo.domain.comment.model.ReplyComment;
+import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 
 public class CommentMapper {
@@ -121,6 +125,20 @@ public class CommentMapper {
 				partyRouteComment.getId(),
 				partyRouteComment.getContent(),
 				partyRouteComment.getImage()
+		);
+	}
+
+	public static ReplyComment toReplyComment(ReplyCommentRegisterRequest replyCommentRegisterRequest, Member member){
+		return ReplyComment.builder()
+				.member(member)
+				.commentId(replyCommentRegisterRequest.commentId())
+				.content(replyCommentRegisterRequest.content())
+				.build();
+	}
+
+	public static ReplyCommentRegisterResponse toReplyCommentRegisterResponse(ReplyComment replyComment){
+		return new ReplyCommentRegisterResponse(
+				replyComment.getId()
 		);
 	}
 }

--- a/src/main/resources/db/migration/V19__create_table_if_not_exists_reply_comment.sql
+++ b/src/main/resources/db/migration/V19__create_table_if_not_exists_reply_comment.sql
@@ -1,0 +1,8 @@
+CREATE TABLE IF NOT EXISTS `reply_comment` (
+`id`	        BIGINT	        NOT NULL PRIMARY KEY AUTO_INCREMENT,
+`member_id`	    BIGINT	        NOT NULL,
+`comment_id`    BIGINT          NOT NULL,
+`content`	    VARCHAR(255)	NOT NULL,
+`created_at`	TIMESTAMP	    NOT NULL,
+`updated_at`	TIMESTAMP	    NOT NULL
+);

--- a/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/api/LocationCommentControllerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.prgrms.wumo.MysqlTestContainer;
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.dto.request.LocationCommentUpdateRequest;
+import org.prgrms.wumo.domain.comment.dto.request.ReplyCommentRegisterRequest;
 import org.prgrms.wumo.domain.comment.model.LocationComment;
 import org.prgrms.wumo.domain.comment.repository.LocationCommentRepository;
 import org.prgrms.wumo.domain.location.model.Category;
@@ -268,6 +269,31 @@ public class LocationCommentControllerTest extends MysqlTestContainer {
 		// Then
 		resultActions
 				.andExpect(status().isOk())
+				.andDo(print());
+	}
+
+	@Test
+	@DisplayName("후보지 댓글에 대댓글을 작성할 수 있다.")
+	void registerReplyComment() throws Exception{
+		// Given
+		ReplyCommentRegisterRequest replyCommentRegisterRequest =
+				new ReplyCommentRegisterRequest(locationComment.getId(), "대댓글 쓰자!!!");
+
+		// When
+		ResultActions resultActions =
+				mockMvc.perform(
+					post("/api/v1/location-comments/replies")
+							.contentType(MediaType.APPLICATION_JSON_VALUE)
+							.characterEncoding("UTF-8")
+							.content(
+									objectMapper.writeValueAsString(replyCommentRegisterRequest)
+							)
+				);
+
+		// Then
+		resultActions
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.id").isNotEmpty())
 				.andDo(print());
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/ReplyCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/ReplyCommentServiceTest.java
@@ -1,0 +1,189 @@
+package org.prgrms.wumo.domain.comment.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.prgrms.wumo.domain.comment.dto.request.ReplyCommentRegisterRequest;
+import org.prgrms.wumo.domain.comment.dto.response.ReplyCommentRegisterResponse;
+import org.prgrms.wumo.domain.comment.model.LocationComment;
+import org.prgrms.wumo.domain.comment.model.ReplyComment;
+import org.prgrms.wumo.domain.comment.repository.LocationCommentRepository;
+import org.prgrms.wumo.domain.comment.repository.ReplyCommentRepository;
+import org.prgrms.wumo.domain.location.model.Category;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@DisplayName("ReplyCommentService 에서")
+@ExtendWith(MockitoExtension.class)
+public class ReplyCommentServiceTest {
+
+	@InjectMocks
+	ReplyCommentService replyCommentService;
+
+	@Mock
+	LocationCommentRepository locationCommentRepository;
+
+	@Mock
+	PartyMemberRepository partyMemberRepository;
+
+	@Mock
+	ReplyCommentRepository replyCommentRepository;
+
+	Member member;
+	LocationComment locationComment;
+	Party party;
+	PartyMember partyMember;
+	Location location;
+	ReplyComment replyComment;
+
+	@BeforeEach
+	void beforeEach() {
+		member = getMember();
+		party = getParty();
+		partyMember = getPartyMember();
+		location = getLocation();
+		locationComment = getLocationComment();
+		replyComment = getReplyComment();
+
+		SecurityContext context = SecurityContextHolder.getContext();
+		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+				new UsernamePasswordAuthenticationToken(member.getId(), null, Collections.EMPTY_LIST);
+
+		context.setAuthentication(usernamePasswordAuthenticationToken);
+	}
+
+	@AfterEach
+	void afterEach() {
+		SecurityContextHolder.clearContext();
+	}
+
+	@Nested
+	@DisplayName("registerReplyComment 를 통해")
+	class RegisterReplyComment {
+		@Test
+		@DisplayName("후보지 댓글에 대댓글을 작성할 수 있다.")
+		void success() {
+			// Given
+			ReplyCommentRegisterRequest replyCommentRegisterRequest =
+				new ReplyCommentRegisterRequest(locationComment.getId(), "대댓글 쓰자!!!");
+
+			given(locationCommentRepository.findById(any(Long.class))).willReturn(Optional.of(locationComment));
+			given(partyMemberRepository.existsById(any(Long.class))).willReturn(true);
+			given(replyCommentRepository.save(any())).willReturn(replyComment);
+
+			// When
+			ReplyCommentRegisterResponse replyCommentRegisterResponse =
+					replyCommentService.registerReplyComment(replyCommentRegisterRequest);
+
+			// Then
+			assertThat(replyCommentRegisterResponse.id()).isEqualTo(1L);
+		}
+
+		@Test
+		@DisplayName("모임의 일원이 아니면 대댓글을 작성할 수 없다.")
+		void failedWithUnAuthorized() {
+			// Given
+			ReplyCommentRegisterRequest replyCommentRegisterRequest =
+				new ReplyCommentRegisterRequest(locationComment.getId(), "대댓글 쓰자!!!");
+
+			given(locationCommentRepository.findById(any(Long.class))).willReturn(Optional.of(locationComment));
+			given(partyMemberRepository.existsById(any(Long.class))).willReturn(false);
+			//given(replyCommentRepository.save(any())).willReturn(replyComment);
+
+			// When // Then
+			assertThatThrownBy(
+					() -> replyCommentService.registerReplyComment(replyCommentRegisterRequest)
+			).isInstanceOf(AccessDeniedException.class);
+		}
+	}
+
+	private Member getMember() {
+		return Member.builder()
+				.id(1L)
+				.password("qwe12345")
+				.email("member@email.com")
+				.nickname("nickname")
+				.build();
+	}
+
+	private Party getParty() {
+		return Party.builder()
+				.id(1L)
+				.description("오예스팀 모임")
+				.coverImage("party_cover_image.png")
+				.name("오예스")
+				.endDate(LocalDateTime.now().plusDays(5))
+				.startDate(LocalDateTime.now().plusDays(2))
+				.build();
+	}
+
+	private PartyMember getPartyMember() {
+		return PartyMember.builder()
+				.id(1L)
+				.member(member)
+				.party(party)
+				.role("총무")
+				.isLeader(true)
+				.build();
+	}
+
+	private LocationComment getLocationComment() {
+		return LocationComment.builder()
+				.id(1L)
+				.image("image.png")
+				.content("댓글 댓글")
+				.locationId(location.getId())
+				.partyMember(partyMember)
+				.member(member)
+				.build();
+	}
+
+	private Location getLocation() {
+		return Location.builder()
+				.id(1L)
+				.image("httpL//.png")
+				.memberId(member.getId())
+				.category(Category.MEAL)
+				.description("딸기 뷔페!! 드디어 예약 성공!! Must Be StrawBerry!!!")
+				.address("서울특별시 중구 을지로 30 페닌슐라 라운지 & 바")
+				.searchAddress("서울특별시")
+				.name("롯데호텔")
+				.latitude(123.45)
+				.longitude(34.45)
+				.partyId(party.getId())
+				.visitDate(LocalDateTime.now())
+				.expectedCost(170000)
+				.build();
+	}
+
+	private ReplyComment getReplyComment() {
+		return ReplyComment.builder()
+				.id(1L)
+				.member(member)
+				.commentId(locationComment.getId())
+				.content("대댓글!!!")
+				.build();
+	}
+}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

대댓글 엔티티 추가 및 등록 기능 구현, 테스트

### ⛏ 중점 사항

대댓글 엔티티가 추가되었습니다!!
- 추후 nosql을 도입하더라도 정합성 보장을 위해 DB 중복 저장을 위해 대댓글을 RDB로 구현했습니다
- 현재 대댓글은 후보지 댓글에서만 작성 가능하므로 location controller 에 엔드포인트를 추가하는 방식으로 구현했습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-344], [[WUMO-345], [WUMO-346]

[WUMO-344]: https://shoekream.atlassian.net/browse/WUMO-344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-345]: https://shoekream.atlassian.net/browse/WUMO-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-346]: https://shoekream.atlassian.net/browse/WUMO-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ