### PR TITLE
[WUMO-367] Member 이메일 관련 기능 쿼리 튜닝

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/api/MemberController.java
@@ -40,7 +40,7 @@ public class MemberController {
 	@GetMapping("/send-code")
 	@Operation(summary = "이메일 인증코드 전송")
 	public ResponseEntity<Void> sendCode(
-		@RequestParam("address") @Parameter(description = "이메일 인증을 원하는 회원의 이메일 주소") String toAddress) {
+			@RequestParam("address") @Parameter(description = "이메일 인증을 원하는 회원의 이메일 주소") String toAddress) {
 
 		memberService.sendCode(toAddress);
 		return ResponseEntity.ok().build();
@@ -49,7 +49,7 @@ public class MemberController {
 	@GetMapping("/check-code")
 	@Operation(summary = "이메일 인증코드 검증")
 	public ResponseEntity<Void> checkCode(
-		@Valid MemberCodeCheckRequest memberCodeCheckRequest) {
+			@Valid MemberCodeCheckRequest memberCodeCheckRequest) {
 
 		memberService.checkCode(memberCodeCheckRequest.address(), memberCodeCheckRequest.code());
 		return ResponseEntity.ok().build();
@@ -58,7 +58,7 @@ public class MemberController {
 	@PostMapping("/signup")
 	@Operation(summary = "회원가입")
 	public ResponseEntity<MemberRegisterResponse> registerMember(
-		@RequestBody @Valid MemberRegisterRequest memberRegisterRequest) {
+			@RequestBody @Valid MemberRegisterRequest memberRegisterRequest) {
 
 		return new ResponseEntity<>(memberService.registerMember(memberRegisterRequest), HttpStatus.CREATED);
 	}
@@ -66,25 +66,25 @@ public class MemberController {
 	@GetMapping("/check-email")
 	@Operation(summary = "이메일 중복체크")
 	public ResponseEntity<Void> checkEmail(
-		@Valid MemberEmailCheckRequest memberEmailCheckRequest) {
+			@Valid MemberEmailCheckRequest memberEmailCheckRequest) {
 
 		memberService.checkEmail(memberEmailCheckRequest.email());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+		return ResponseEntity.ok().build();
 	}
 
 	@GetMapping("/check-nickname")
 	@Operation(summary = "닉네임 중복체크")
 	public ResponseEntity<Void> checkNickname(
-		@Valid MemberNicknameCheckRequest memberNicknameCheckRequest) {
+			@Valid MemberNicknameCheckRequest memberNicknameCheckRequest) {
 
 		memberService.checkNickname(memberNicknameCheckRequest.nickname());
-		return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+		return ResponseEntity.ok().build();
 	}
 
 	@PostMapping("/login")
 	@Operation(summary = "로그인")
 	public ResponseEntity<MemberLoginResponse> loginMember(
-		@RequestBody @Valid MemberLoginRequest memberLoginRequest) {
+			@RequestBody @Valid MemberLoginRequest memberLoginRequest) {
 
 		return ResponseEntity.ok(memberService.loginMember(memberLoginRequest));
 	}
@@ -100,7 +100,7 @@ public class MemberController {
 	@PostMapping("/reissue")
 	@Operation(summary = "토큰 재발급")
 	public ResponseEntity<MemberLoginResponse> reissueMember(
-		@RequestBody @Valid MemberReissueRequest memberReissueRequest
+			@RequestBody @Valid MemberReissueRequest memberReissueRequest
 	) {
 
 		return ResponseEntity.ok(memberService.reissueMember(memberReissueRequest));
@@ -116,7 +116,7 @@ public class MemberController {
 	@PatchMapping
 	@Operation(summary = "내 정보 수정")
 	public ResponseEntity<MemberGetResponse> updateMember(
-		@RequestBody @Valid MemberUpdateRequest memberUpdateRequest) {
+			@RequestBody @Valid MemberUpdateRequest memberUpdateRequest) {
 
 		return ResponseEntity.ok(memberService.updateMember(memberUpdateRequest));
 	}

--- a/src/main/java/org/prgrms/wumo/domain/member/repository/MemberCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/repository/MemberCustomRepository.java
@@ -1,0 +1,5 @@
+package org.prgrms.wumo.domain.member.repository;
+
+public interface MemberCustomRepository {
+	boolean existsByEmail(String email);
+}

--- a/src/main/java/org/prgrms/wumo/domain/member/repository/MemberCustomRepositoryImpl.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/repository/MemberCustomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package org.prgrms.wumo.domain.member.repository;
+
+import org.prgrms.wumo.domain.member.model.QMember;
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberCustomRepositoryImpl implements MemberCustomRepository {
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	private final QMember qMember = QMember.member;
+
+	@Override
+	public boolean existsByEmail(String email) {
+		Integer fetchOne = jpaQueryFactory
+				.selectOne()
+				.from(qMember)
+				.where(qMember.email.email.eq(email))
+				.fetchFirst();
+		return fetchOne != null;
+	}
+}

--- a/src/main/java/org/prgrms/wumo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/repository/MemberRepository.java
@@ -2,14 +2,11 @@ package org.prgrms.wumo.domain.member.repository;
 
 import java.util.Optional;
 
-import org.prgrms.wumo.domain.member.model.Email;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface MemberRepository extends JpaRepository<Member, Long> {
-	boolean existsByEmail(Email email);
-
+public interface MemberRepository extends JpaRepository<Member, Long>, MemberCustomRepository {
 	boolean existsByNickname(String nickname);
 
 	@Query(value = "select m from Member m where m.email.email = :email")

--- a/src/main/java/org/prgrms/wumo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/repository/MemberRepository.java
@@ -5,11 +5,13 @@ import java.util.Optional;
 import org.prgrms.wumo.domain.member.model.Email;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByEmail(Email email);
 
 	boolean existsByNickname(String nickname);
 
-	Optional<Member> findByEmail(Email email);
+	@Query(value = "select m from Member m where m.email.email = :email")
+	Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -84,8 +84,8 @@ public class MemberService {
 
 	@Transactional
 	public MemberLoginResponse loginMember(MemberLoginRequest memberLoginRequest) {
-		Member member = memberRepository.findByEmail(new Email(memberLoginRequest.email()))
-			.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
+		Member member = memberRepository.findByEmail(memberLoginRequest.email())
+				.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
 
 		if (member.isNotValidPassword(memberLoginRequest.password())) {
 			throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
@@ -132,9 +132,9 @@ public class MemberService {
 
 		Member member = getMemberEntity(memberId);
 		member.update(
-			memberUpdateRequest.nickname(),
-			memberUpdateRequest.password(),
-			memberUpdateRequest.profileImage()
+				memberUpdateRequest.nickname(),
+				memberUpdateRequest.password(),
+				memberUpdateRequest.profileImage()
 		);
 		return toMemberGetResponse(memberRepository.save(member));
 	}
@@ -142,16 +142,16 @@ public class MemberService {
 	private WumoJwt getWumoJwt(String memberId) {
 		WumoJwt wumoJwt = jwtTokenProvider.generateToken(memberId);
 		redisRepository.save(
-			memberId,
-			wumoJwt.getRefreshToken(),
-			jwtTokenProvider.getRefreshTokenExpireSeconds()
+				memberId,
+				wumoJwt.getRefreshToken(),
+				jwtTokenProvider.getRefreshTokenExpireSeconds()
 		);
 		return wumoJwt;
 	}
 
 	private Member getMemberEntity(long memberId) {
 		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
+				.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
 	}
 
 	private void validateAccess(long memberId) {

--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -16,7 +16,6 @@ import org.prgrms.wumo.domain.member.dto.request.MemberUpdateRequest;
 import org.prgrms.wumo.domain.member.dto.response.MemberGetResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberLoginResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberRegisterResponse;
-import org.prgrms.wumo.domain.member.model.Email;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.global.event.MemberCreateEvent;
@@ -161,7 +160,7 @@ public class MemberService {
 	}
 
 	private boolean checkEmailDuplicate(String email) {
-		return memberRepository.existsByEmail(new Email(email));
+		return memberRepository.existsByEmail(email);
 	}
 
 	private boolean checkNicknameDuplicate(String nickname) {

--- a/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/api/MemberControllerTest.java
@@ -53,7 +53,7 @@ public class MemberControllerTest extends MysqlTestContainer {
 
 		SecurityContext context = SecurityContextHolder.getContext();
 		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-			new UsernamePasswordAuthenticationToken(memberId, null, Collections.EMPTY_LIST);
+				new UsernamePasswordAuthenticationToken(memberId, null, Collections.EMPTY_LIST);
 
 		context.setAuthentication(usernamePasswordAuthenticationToken);
 	}
@@ -69,19 +69,19 @@ public class MemberControllerTest extends MysqlTestContainer {
 	void register_member() throws Exception {
 		//given
 		MemberRegisterRequest memberRegisterRequest
-			= new MemberRegisterRequest("5yes@gmail.com", "오예스", "qwe12345");
+				= new MemberRegisterRequest("5yes@gmail.com", "오예스", "qwe12345");
 
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/members/signup")
-			.contentType(MediaType.APPLICATION_JSON_VALUE)
-			.content(objectMapper.writeValueAsString(memberRegisterRequest)));
+				= mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/members/signup")
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.content(objectMapper.writeValueAsString(memberRegisterRequest)));
 
 		//then
 		resultActions
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("$.id").isNotEmpty())
-			.andDo(print());
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.id").isNotEmpty())
+				.andDo(print());
 	}
 
 	@Test
@@ -92,12 +92,12 @@ public class MemberControllerTest extends MysqlTestContainer {
 
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/check-email")
-			.param("email", email));
+				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/check-email")
+				.param("email", email));
 
 		//then
 		resultActions
-			.andExpect(status().isNoContent());
+				.andExpect(status().isOk());
 	}
 
 	@Test
@@ -108,12 +108,12 @@ public class MemberControllerTest extends MysqlTestContainer {
 
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/check-nickname")
-			.param("nickname", nickname));
+				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members/check-nickname")
+				.param("nickname", nickname));
 
 		//then
 		resultActions
-			.andExpect(status().isNoContent());
+				.andExpect(status().isOk());
 	}
 
 	@Test
@@ -121,16 +121,16 @@ public class MemberControllerTest extends MysqlTestContainer {
 	void get_member() throws Exception {
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members"));
+				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/members"));
 
 		//then
 		resultActions
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").value(memberId))
-			.andExpect(jsonPath("$.email").value("taehee@gmail.com"))
-			.andExpect(jsonPath("$.nickname").value("태희"))
-			.andExpect(jsonPath("$.profileImage").isEmpty())
-			.andDo(print());
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(memberId))
+				.andExpect(jsonPath("$.email").value("taehee@gmail.com"))
+				.andExpect(jsonPath("$.nickname").value("태희"))
+				.andExpect(jsonPath("$.profileImage").isEmpty())
+				.andDo(print());
 	}
 
 	@Test
@@ -138,28 +138,28 @@ public class MemberControllerTest extends MysqlTestContainer {
 	void update_member() throws Exception {
 		//given
 		MemberUpdateRequest memberUpdateRequest
-			= new MemberUpdateRequest(memberId, "태희수정", "asd67890", null);
+				= new MemberUpdateRequest(memberId, "태희수정", "asd67890", null);
 
 		//when
 		ResultActions resultActions
-			= mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/members")
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(objectMapper.writeValueAsString(memberUpdateRequest)));
+				= mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/members")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(objectMapper.writeValueAsString(memberUpdateRequest)));
 
 		//then
 		resultActions
-			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.id").value(memberId))
-			.andExpect(jsonPath("$.nickname").value("태희수정"))
-			.andExpect(jsonPath("$.profileImage").isEmpty())
-			.andDo(print());
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.id").value(memberId))
+				.andExpect(jsonPath("$.nickname").value("태희수정"))
+				.andExpect(jsonPath("$.profileImage").isEmpty())
+				.andDo(print());
 	}
 
 	private Member getMemberData() {
 		return Member.builder()
-			.email("taehee@gmail.com")
-			.nickname("태희")
-			.password("qwe12345")
-			.build();
+				.email("taehee@gmail.com")
+				.nickname("태희")
+				.password("qwe12345")
+				.build();
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -66,7 +66,7 @@ public class MemberServiceTest {
 	void setUp() {
 		SecurityContext context = SecurityContextHolder.getContext();
 		UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-			new UsernamePasswordAuthenticationToken(1L, null, Collections.EMPTY_LIST);
+				new UsernamePasswordAuthenticationToken(1L, null, Collections.EMPTY_LIST);
 
 		context.setAuthentication(usernamePasswordAuthenticationToken);
 	}
@@ -85,7 +85,7 @@ public class MemberServiceTest {
 		String password = "qwe12345";
 
 		MemberRegisterRequest memberRegisterRequest
-			= new MemberRegisterRequest(email, nickname, password);
+				= new MemberRegisterRequest(email, nickname, password);
 
 		Member member = getMemberData(email, nickname, password);
 
@@ -94,7 +94,7 @@ public class MemberServiceTest {
 		void success() {
 			//mocking
 			given(memberRepository.save(any(Member.class)))
-				.willReturn(member);
+					.willReturn(member);
 
 			//when
 			MemberRegisterResponse result = memberService.registerMember(memberRegisterRequest);
@@ -102,8 +102,8 @@ public class MemberServiceTest {
 			//then
 			assertThat(result.id()).isEqualTo(1L);
 			then(memberRepository)
-				.should()
-				.save(any(Member.class));
+					.should()
+					.save(any(Member.class));
 		}
 	}
 
@@ -114,19 +114,19 @@ public class MemberServiceTest {
 		String email = "5yes@gmail.com";
 
 		MemberEmailCheckRequest memberEmailCheckRequest
-			= new MemberEmailCheckRequest(email);
+				= new MemberEmailCheckRequest(email);
 
 		@Test
 		@DisplayName("이미 가입된 이메일이라면 예외가 발생한다")
 		void fail_with_exist_emil() {
 			//mocking
 			given(memberRepository.existsByEmail(any(Email.class)))
-				.willReturn(true);
+					.willReturn(true);
 
 			//when, then
 			assertThatThrownBy(() -> memberService.checkEmail(memberEmailCheckRequest.email()))
-				.isInstanceOf(DuplicateException.class)
-				.hasMessage("이메일이 중복됩니다.");
+					.isInstanceOf(DuplicateException.class)
+					.hasMessage("이메일이 중복됩니다.");
 		}
 	}
 
@@ -137,19 +137,19 @@ public class MemberServiceTest {
 		String nickname = "오예스";
 
 		MemberNicknameCheckRequest memberNicknameCheckRequest
-			= new MemberNicknameCheckRequest(nickname);
+				= new MemberNicknameCheckRequest(nickname);
 
 		@Test
 		@DisplayName("이미 사용중인 닉네임이라면 예외가 발생한다")
 		void fail_with_exist_emil() {
 			//mocking
 			given(memberRepository.existsByNickname(anyString()))
-				.willReturn(true);
+					.willReturn(true);
 
 			//when, then
 			assertThatThrownBy(() -> memberService.checkNickname(memberNicknameCheckRequest.nickname()))
-				.isInstanceOf(DuplicateException.class)
-				.hasMessage("닉네임이 중복됩니다.");
+					.isInstanceOf(DuplicateException.class)
+					.hasMessage("닉네임이 중복됩니다.");
 		}
 	}
 
@@ -162,24 +162,24 @@ public class MemberServiceTest {
 		String password = "qwe12345";
 
 		MemberLoginRequest memberLoginRequest
-			= new MemberLoginRequest(email, password);
+				= new MemberLoginRequest(email, password);
 
 		Member member = getMemberData(email, nickname, password);
 
 		WumoJwt wumoJwt = WumoJwt.builder()
-			.grantType("grant type")
-			.accessToken("access token")
-			.refreshToken("refresh token")
-			.build();
+				.grantType("grant type")
+				.accessToken("access token")
+				.refreshToken("refresh token")
+				.build();
 
 		@Test
 		@DisplayName("성공하면 jwt token을 반환한다")
 		void success() {
 			//mocking
-			given(memberRepository.findByEmail(any(Email.class)))
-				.willReturn(Optional.of(member));
+			given(memberRepository.findByEmail(anyString()))
+					.willReturn(Optional.of(member));
 			given(jwtTokenProvider.generateToken(anyString()))
-				.willReturn(wumoJwt);
+					.willReturn(wumoJwt);
 
 			//when
 			MemberLoginResponse result = memberService.loginMember(memberLoginRequest);
@@ -187,24 +187,24 @@ public class MemberServiceTest {
 			//then
 			assertThat(result).usingRecursiveComparison().isEqualTo(wumoJwt);
 			then(memberRepository)
-				.should()
-				.findByEmail(any(Email.class));
+					.should()
+					.findByEmail(anyString());
 			then(jwtTokenProvider)
-				.should()
-				.generateToken(anyString());
+					.should()
+					.generateToken(anyString());
 		}
 
 		@Test
 		@DisplayName("이메일이 일치하지 않으면 예외가 발생한다")
 		void fail_not_match_email() {
 			//mocking
-			given(memberRepository.findByEmail(any(Email.class)))
-				.willReturn(Optional.ofNullable(null));
+			given(memberRepository.findByEmail(anyString()))
+					.willReturn(Optional.ofNullable(null));
 
 			//when, then
 			assertThatThrownBy(() -> memberService.loginMember(memberLoginRequest))
-				.isInstanceOf(EntityNotFoundException.class)
-				.hasMessage("일치하는 회원이 없습니다.");
+					.isInstanceOf(EntityNotFoundException.class)
+					.hasMessage("일치하는 회원이 없습니다.");
 		}
 
 		@Test
@@ -213,15 +213,15 @@ public class MemberServiceTest {
 			//mocking
 			String wrongPassword = "asd12345";
 			MemberLoginRequest wrongMemberLoginRequest
-				= new MemberLoginRequest(email, wrongPassword);
+					= new MemberLoginRequest(email, wrongPassword);
 
-			given(memberRepository.findByEmail(any(Email.class)))
-				.willReturn(Optional.of(member));
+			given(memberRepository.findByEmail(anyString()))
+					.willReturn(Optional.of(member));
 
 			//when, then
 			assertThatThrownBy(() -> memberService.loginMember(wrongMemberLoginRequest))
-				.isInstanceOf(BadCredentialsException.class)
-				.hasMessage("비밀번호가 일치하지 않습니다.");
+					.isInstanceOf(BadCredentialsException.class)
+					.hasMessage("비밀번호가 일치하지 않습니다.");
 		}
 	}
 
@@ -241,7 +241,7 @@ public class MemberServiceTest {
 		void success() {
 			//mocking
 			given(memberRepository.findById(anyLong()))
-				.willReturn(Optional.of(member));
+					.willReturn(Optional.of(member));
 
 			//when
 			MemberGetResponse result = memberService.getMember();
@@ -249,8 +249,8 @@ public class MemberServiceTest {
 			//then
 			assertThat(result.nickname()).isEqualTo(member.getNickname());
 			then(memberRepository)
-				.should()
-				.findById(anyLong());
+					.should()
+					.findById(anyLong());
 		}
 	}
 
@@ -266,7 +266,7 @@ public class MemberServiceTest {
 		String passwordAfter = "asd56789";
 
 		MemberUpdateRequest memberUpdateRequest
-			= new MemberUpdateRequest(1L, nicknameAfter, passwordAfter, null);
+				= new MemberUpdateRequest(1L, nicknameAfter, passwordAfter, null);
 
 		Member memberBefore = getMemberData(email, nicknameBefore, passwordBefore);
 		Member memberAfter = getMemberData(email, nicknameAfter, passwordAfter);
@@ -276,9 +276,9 @@ public class MemberServiceTest {
 		void success() {
 			//mocking
 			given(memberRepository.findById(anyLong()))
-				.willReturn(Optional.of(memberBefore));
+					.willReturn(Optional.of(memberBefore));
 			given(memberRepository.save(any(Member.class)))
-				.willReturn(memberAfter);
+					.willReturn(memberAfter);
 
 			//when
 			MemberGetResponse result = memberService.updateMember(memberUpdateRequest);
@@ -286,20 +286,20 @@ public class MemberServiceTest {
 			//then
 			assertThat(result.nickname()).isEqualTo(nicknameAfter);
 			then(memberRepository)
-				.should()
-				.findById(anyLong());
+					.should()
+					.findById(anyLong());
 			then(memberRepository)
-				.should()
-				.save(any(Member.class));
+					.should()
+					.save(any(Member.class));
 		}
 	}
 
 	private Member getMemberData(String email, String nickname, String password) {
 		return Member.builder()
-			.id(1L)
-			.email(email)
-			.nickname(nickname)
-			.password(password)
-			.build();
+				.id(1L)
+				.email(email)
+				.nickname(nickname)
+				.password(password)
+				.build();
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -30,7 +30,6 @@ import org.prgrms.wumo.domain.member.dto.request.MemberUpdateRequest;
 import org.prgrms.wumo.domain.member.dto.response.MemberGetResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberLoginResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberRegisterResponse;
-import org.prgrms.wumo.domain.member.model.Email;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
@@ -120,7 +119,7 @@ public class MemberServiceTest {
 		@DisplayName("이미 가입된 이메일이라면 예외가 발생한다")
 		void fail_with_exist_emil() {
 			//mocking
-			given(memberRepository.existsByEmail(any(Email.class)))
+			given(memberRepository.existsByEmail(anyString()))
 					.willReturn(true);
 
 			//when, then


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 이메일 중복체크 쿼리문 수정
- 이메일로 회원찾기 쿼리문 수정

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- Member의 Email을 Embedded type으로 관리하고 있어    
메소드쿼리 사용 시, 불필요한 Email 객체를 생성해야 하는 경우가 있어 리팩토링 하였습니다
- jpql은 select exists 문법 미지원, where 절에서 사용 시에는 count 쿼리 사용함으로 인한 성능상 이슈가 발생해 querydsl을 사용하였습니다
- 중복 체크 시 중복이 없다면 응답하는 http status code를 204(no content)에서 200(ok)로 변경하였습니다 (204는 있던 리소스가 삭제 후 없다는 의미이기 때문에 적절하지 못하다고 판단함)

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-368], [WUMO-369]

[WUMO-368]: https://shoekream.atlassian.net/browse/WUMO-368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-369]: https://shoekream.atlassian.net/browse/WUMO-369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ