### PR TITLE
[WUMO-374] Location 실제 사용 금액 수정 권한 변경

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/model/Location.java
@@ -80,7 +80,8 @@ public class Location extends BaseTimeEntity {
 	private Long partyId;
 
 	@Builder
-	public Location(Long id, Long memberId, String name, String address, String searchAddress, Double latitude, Double longitude,
+	public Location(Long id, Long memberId, String name, String address, String searchAddress, Double latitude,
+			Double longitude,
 			String image,
 			String description,
 			LocalDateTime visitDate, int expectedCost, int spending, Category category, Route route, Long partyId) {
@@ -121,8 +122,9 @@ public class Location extends BaseTimeEntity {
 		this.spending = spending;
 	}
 
-	public void checkAuthorization(Long memberId){
-		if (!Objects.equals(this.memberId, memberId))
-			throw new AccessDeniedException("후보지는 작성자 및 모임장만 삭제할 수 있습니다.");
+	public void checkAuthorization(Long memberId) {
+		if (!Objects.equals(this.memberId, memberId)) {
+			throw new AccessDeniedException("후보지는 작성자 및 모임장만 수정 및 삭제할 수 있습니다.");
+		}
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -99,7 +99,7 @@ public class LocationService {
 	public LocationSpendingUpdateResponse updateSpending(LocationSpendingUpdateRequest locationSpendingUpdateRequest) {
 		Location location = getLocationEntity(locationSpendingUpdateRequest.locationId());
 
-		checkAuthorization(location, getMemberId());
+		checkMemberInParty(location.getPartyId(), getMemberId());
 
 		location.updateSpending(locationSpendingUpdateRequest.spending());
 
@@ -110,7 +110,7 @@ public class LocationService {
 
 	private Location getLocationEntity(Long locationId) {
 		return locationRepository.findById(locationId)
-				.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보 장소입니다"));
+				.orElseThrow(() -> new EntityNotFoundException("존재하지 않는 후보지입니다"));
 	}
 
 	private void checkMemberInParty(Long partyId, Long memberId) {

--- a/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
@@ -341,8 +341,7 @@ public class LocationServiceTest {
 		void success() {
 			// Given
 			given(locationRepository.findById(any(Long.class))).willReturn(Optional.of(locationTestUtils.getLocation()));
-			given(partyMemberRepository.findByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(Optional.of(
-					leaderPartyMember));
+			given(partyMemberRepository.existsByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(true);
 
 			// When
 			LocationSpendingUpdateResponse locationSpendingUpdateResponse =
@@ -357,12 +356,11 @@ public class LocationServiceTest {
 		}
 
 		@Test
-		@DisplayName("본인이 올린 후보지가 아니거나 모임장이 아니면 금액을 갱신할 수 없다.")
+		@DisplayName("모임의 외부인은 실제 사용 금액을 갱신할 수 없다.")
 		void failedUnAuthorized() {
 			// Given
 			given(locationRepository.findById(any(Long.class))).willReturn(Optional.of(locationTestUtils.getLocation()));
-			given(partyMemberRepository.findByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(Optional.of(
-					normalPartyMember));
+			given(partyMemberRepository.existsByPartyIdAndMemberId(any(Long.class), any(Long.class))).willReturn(false);
 
 			// When // Then
 			assertThatThrownBy(


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

후보지 실제 사용 금액 수정 권한 변경

### ⛏ 중점 사항

후보지에서 실사용한 금액의 수정 권한을 변경함
- 변경 전 : 모임장 및 후보지 등록인(후보지 수정 삭제 권한과 동일)
- 변경 후 : 모임내 모든 인원

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-375], [WUMO-376]

[WUMO-375]: https://shoekream.atlassian.net/browse/WUMO-375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-376]: https://shoekream.atlassian.net/browse/WUMO-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ