### PR TITLE
[WUMO-379] 공통 예외메시지 Enum으로 관리

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -19,6 +19,7 @@ import org.prgrms.wumo.domain.member.dto.response.MemberRegisterResponse;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.global.event.MemberCreateEvent;
+import org.prgrms.wumo.global.exception.ExceptionMessage;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
 import org.prgrms.wumo.global.exception.custom.InvalidCodeException;
 import org.prgrms.wumo.global.exception.custom.InvalidRefreshTokenException;
@@ -84,7 +85,9 @@ public class MemberService {
 	@Transactional
 	public MemberLoginResponse loginMember(MemberLoginRequest memberLoginRequest) {
 		Member member = memberRepository.findByEmail(memberLoginRequest.email())
-				.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
+				.orElseThrow(() -> new EntityNotFoundException(
+						String.format(ExceptionMessage.ENTITY_NOT_FOUND.name(), ExceptionMessage.MEMBER.name())
+				));
 
 		if (member.isNotValidPassword(memberLoginRequest.password())) {
 			throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
@@ -150,12 +153,14 @@ public class MemberService {
 
 	private Member getMemberEntity(long memberId) {
 		return memberRepository.findById(memberId)
-				.orElseThrow(() -> new EntityNotFoundException("일치하는 회원이 없습니다."));
+				.orElseThrow(() -> new EntityNotFoundException(
+						String.format(ExceptionMessage.ENTITY_NOT_FOUND.name(), ExceptionMessage.MEMBER.name())
+				));
 	}
 
 	private void validateAccess(long memberId) {
 		if (!isValidAccess(memberId)) {
-			throw new AccessDeniedException("잘못된 접근입니다.");
+			throw new AccessDeniedException(ExceptionMessage.WRONG_ACCESS.name());
 		}
 	}
 

--- a/src/main/java/org/prgrms/wumo/global/exception/ExceptionMessage.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/ExceptionMessage.java
@@ -8,7 +8,7 @@ public enum ExceptionMessage {
 	ROUTE("루트"),
 	COMMENT("댓글"),
 	ENTITY_NOT_FOUND("존재하지 않는 %s 입니다."),
-	ACCESS_DENIED("잘못된 접근입니다.");
+	WRONG_ACCESS("잘못된 접근입니다.");
 
 	private final String message;
 

--- a/src/main/java/org/prgrms/wumo/global/exception/ExceptionMessage.java
+++ b/src/main/java/org/prgrms/wumo/global/exception/ExceptionMessage.java
@@ -1,0 +1,18 @@
+package org.prgrms.wumo.global.exception;
+
+public enum ExceptionMessage {
+	MEMBER("회원"),
+	PARTY("모임"),
+	PARTY_MEMBER("모임 멤버"),
+	LOCATION("후보지"),
+	ROUTE("루트"),
+	COMMENT("댓글"),
+	ENTITY_NOT_FOUND("존재하지 않는 %s 입니다."),
+	ACCESS_DENIED("잘못된 접근입니다.");
+
+	private final String message;
+
+	ExceptionMessage(String message) {
+		this.message = message;
+	}
+}

--- a/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/member/service/MemberServiceTest.java
@@ -32,6 +32,7 @@ import org.prgrms.wumo.domain.member.dto.response.MemberLoginResponse;
 import org.prgrms.wumo.domain.member.dto.response.MemberRegisterResponse;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
+import org.prgrms.wumo.global.exception.ExceptionMessage;
 import org.prgrms.wumo.global.exception.custom.DuplicateException;
 import org.prgrms.wumo.global.jwt.JwtTokenProvider;
 import org.prgrms.wumo.global.jwt.WumoJwt;
@@ -203,7 +204,7 @@ public class MemberServiceTest {
 			//when, then
 			assertThatThrownBy(() -> memberService.loginMember(memberLoginRequest))
 					.isInstanceOf(EntityNotFoundException.class)
-					.hasMessage("일치하는 회원이 없습니다.");
+					.hasMessage(String.format(ExceptionMessage.ENTITY_NOT_FOUND.name(), ExceptionMessage.MEMBER.name()));
 		}
 
 		@Test


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 공통 예외메시지 Enum으로 관리
- 모든 도메인에서 공통적으로 사용하는 예외와 관련된 메시지들만 모아두었습니다

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 빠진 예외메시지가 있다면 말씀해주세요

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-381], [WUMO-382]

[WUMO-381]: https://shoekream.atlassian.net/browse/WUMO-381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-382]: https://shoekream.atlassian.net/browse/WUMO-382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ