### PR TITLE
[WUMO-387] PartyMember 등록시 역할 Nullable 허용

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyMemberRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyMemberRegisterRequest.java
@@ -1,14 +1,14 @@
 package org.prgrms.wumo.domain.party.dto.request;
 
-import javax.validation.constraints.NotBlank;
+import org.hibernate.validator.constraints.Length;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "모임 구성원 등록 요청 정보")
 public record PartyMemberRegisterRequest(
 
-		@NotBlank
-		@Schema(description = "역할", example = "총무", requiredMode = Schema.RequiredMode.REQUIRED)
+		@Length(min = 0, max = 10, message = "역할은 {min}자 이상 {max}자 이하만 가능합니다.")
+		@Schema(description = "역할", example = "총무", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
 		String role
 
 ) {

--- a/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/dto/request/PartyRegisterRequest.java
@@ -26,7 +26,7 @@ public record PartyRegisterRequest(
 		LocalDate endDate,
 
 		@NotBlank(message = "모임 설명은 필수 입력사항입니다.")
-		@Length(max = 255, message = "모임 설명은 {max}자를 초과할 수 없습니다.")
+		@Length(max = 100, message = "모임 설명은 {max}자를 초과할 수 없습니다.")
 		@Schema(description = "모임 설명", example = "팀 설립 기념 워크샵", requiredMode = Schema.RequiredMode.REQUIRED)
 		String description,
 

--- a/src/main/java/org/prgrms/wumo/domain/party/model/Party.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/model/Party.java
@@ -39,7 +39,7 @@ public class Party extends BaseTimeEntity {
 	@Column(name = "end_date", nullable = false, unique = false)
 	private LocalDateTime endDate;
 
-	@Column(name = "description", nullable = true, unique = false, length = 255)
+	@Column(name = "description", nullable = true, unique = false, length = 100)
 	private String description;
 
 	@Column(name = "image_url", nullable = false, unique = false, length = 255)


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- PartyMember 등록시 역할 Nullable 허용 

### ⛏ 중점 사항

- 프론트엔드 요구사항 중 "초대 코드를 통한 모임 참여 시 역할은 지정하지 않고 나중에 설정"에 대한 반영 사항입니다.
  - [WUMO-41] 에 대한 요구사항 변경입니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-41], [WUMO-387]

[WUMO-41]: https://shoekream.atlassian.net/browse/WUMO-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-41]: https://shoekream.atlassian.net/browse/WUMO-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-387]: https://shoekream.atlassian.net/browse/WUMO-387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ