### PR TITLE
[WUMO-399] RouteLike 집계(Batch) COUNT 0 이슈 수정

### DIFF
--- a/src/main/java/org/prgrms/wumo/batch/like/RouteLikeBatchComponent.java
+++ b/src/main/java/org/prgrms/wumo/batch/like/RouteLikeBatchComponent.java
@@ -1,9 +1,9 @@
 package org.prgrms.wumo.batch.like;
 
-import java.util.Comparator;
-import java.util.Map;
+import java.util.List;
 
 import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
+import org.springframework.data.util.Pair;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,23 +14,23 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RouteLikeBatchComponent {
 
-	private static final int BATCH_FREQUENCY = 600000;
+	private static final int BATCH_FREQUENCY = 600000; 	// MilliSeconds
 
-	private static final int BATCH_SIZE = 1000;
+	private static final int BATCH_SIZE = 1000;					// COUNT Record Result Size
 
 	private final RouteLikeRepository routeLikeRepository;
 
 	@Transactional
 	@Scheduled(fixedRate = BATCH_FREQUENCY)
 	public void synchronizeRouteLikeCount() {
-		Map<Long, Long> routeLikes;
+		List<Pair<Long, Long>> resultSet;
 		Long cursorId = null;
 		do {
-			routeLikes = routeLikeRepository.countAllByRouteId(cursorId, BATCH_SIZE);
+			resultSet = routeLikeRepository.countAllByRouteId(cursorId, BATCH_SIZE);
 
-			cursorId = routeLikes.keySet().isEmpty() ? -1L : routeLikes.keySet().stream().max(Comparator.naturalOrder()).get();
-			
-			routeLikeRepository.updateLikeCount(routeLikes);
+			cursorId = resultSet.isEmpty() ? -1L : resultSet.get(resultSet.size() - 1).getFirst();
+
+			routeLikeRepository.updateLikeCount(resultSet);
 		} while (!cursorId.equals(-1L));
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepository.java
@@ -1,7 +1,6 @@
 package org.prgrms.wumo.domain.like.repository;
 
 import java.util.List;
-import java.util.Map;
 
 import org.prgrms.wumo.domain.route.model.Route;
 import org.springframework.data.util.Pair;
@@ -10,8 +9,8 @@ public interface RouteLikeCustomRepository {
 
 	Pair<List<Long>, List<Route>> findAllByMemberId(Long memberId, Long cursorId, int pageSize);
 
-	Map<Long, Long> countAllByRouteId(Long cursorId, int batchSize);
+	List<Pair<Long, Long>> countAllByRouteId(Long cursorId, int batchSize);
 
-	void updateLikeCount(Map<Long, Long> likeCounts);
+	void updateLikeCount(List<Pair<Long, Long>> resultSet);
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepositoryImpl.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepositoryImpl.java
@@ -1,18 +1,11 @@
 package org.prgrms.wumo.domain.like.repository;
 
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.prgrms.wumo.domain.like.model.QRouteLike;
 import org.prgrms.wumo.domain.route.model.QRoute;
 import org.prgrms.wumo.domain.route.model.Route;
 import org.springframework.data.util.Pair;
-import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
@@ -62,46 +55,42 @@ public class RouteLikeCustomRepositoryImpl implements RouteLikeCustomRepository 
 	}
 
 	@Override
-	public Map<Long, Long> countAllByRouteId(Long cursorId, int batchSize) {
-		List<Tuple> tuples = jpaQueryFactory
-				.select(qRouteLike.routeId, qRouteLike.count())
-				.from(qRouteLike)
+	public List<Pair<Long, Long>> countAllByRouteId(Long cursorId, int batchSize) {
+		return jpaQueryFactory
+				.select(qRoute.id, qRouteLike.id.count().coalesce(0L))
+				.from(qRoute)
 				.where(gtRouteId(cursorId))
-				.groupBy(qRouteLike.routeId)
-				.orderBy(qRouteLike.routeId.asc())
+				.leftJoin(qRouteLike)
+				.on(qRouteLike.routeId.eq(qRoute.id))
+				.groupBy(qRoute.id)
+				.orderBy(qRoute.id.asc())
 				.limit(batchSize)
-				.fetch();
-
-		HashMap<Long, Long> hashMap = new HashMap<>();
-		tuples.forEach(tuple -> hashMap.put(tuple.get(0, Long.class), tuple.get(1, Long.class)));
-		return hashMap;
+				.fetch()
+				.stream()
+				.map(row -> Pair.of(row.get(0, Long.class), row.get(1, Long.class)))
+				.toList();
 	}
 
 	@Override
-	public void updateLikeCount(Map<Long, Long> likeCounts) {
-		Timestamp NOW = Timestamp.valueOf(LocalDateTime.now());
-		List<Long> routeIds = likeCounts.keySet().stream().toList();
+	public void updateLikeCount(List<Pair<Long, Long>> resultSet) {
+		if (resultSet.size() > 0) {
+			StringBuilder sql = new StringBuilder();
+			sql.append("UPDATE route SET like_count = CASE ");
+			resultSet.forEach(
+					pair -> sql.append(String.format("WHEN id = %d THEN %d ", pair.getFirst(), pair.getSecond()))
+			);
+			sql.append(
+					String.format(
+							"END WHERE id BETWEEN %d AND %d;", resultSet.get(0).getFirst(), resultSet.get(resultSet.size() - 1).getFirst()
+					)
+			);
 
-		jdbcTemplate.batchUpdate(
-				"UPDATE route SET like_count = ?, updated_at = ? WHERE id = ?",
-				new BatchPreparedStatementSetter() {
-					@Override
-					public void setValues(PreparedStatement ps, int i) throws SQLException {
-						ps.setLong(1, likeCounts.get(routeIds.get(i)));
-						ps.setTimestamp(2, NOW);
-						ps.setLong(3, routeIds.get(i));
-					}
-
-					@Override
-					public int getBatchSize() {
-						return routeIds.size();
-					}
-				}
-		);
+			jdbcTemplate.update(sql.toString());
+		}
 	}
 
 	private BooleanExpression gtRouteId(Long cursorId) {
-		return (cursorId != null) ? qRouteLike.routeId.gt(cursorId) : null;
+		return (cursorId != null) ? qRoute.id.gt(cursorId) : null;
 	}
 
 	private BooleanExpression eqMemberId(Long memberId) {

--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepositoryImpl.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeCustomRepositoryImpl.java
@@ -14,7 +14,9 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class RouteLikeCustomRepositoryImpl implements RouteLikeCustomRepository {
@@ -84,6 +86,11 @@ public class RouteLikeCustomRepositoryImpl implements RouteLikeCustomRepository 
 							"END WHERE id BETWEEN %d AND %d;", resultSet.get(0).getFirst(), resultSet.get(resultSet.size() - 1).getFirst()
 					)
 			);
+
+			if (sql.toString().getBytes().length > 1024 * 1024) {
+				log.error("UPDATE 쿼리문의 길이가 1M을 초과하여 실행할 수 없습니다. 배치 사이즈를 조절해야 합니다.");
+				return;
+			}
 
 			jdbcTemplate.update(sql.toString());
 		}


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- RouteLike 집계(Batch) COUNT 0 이슈 수정

### ⛏ 중점 사항

- COUNT시 좋아요가 없는 Route ID는 집계되지 않는 문제
  - 예를 들어 좋아요가 1개이던 루트의 좋아요가 취소되면 COUNT 결과에 포함되지 않음
  - 따라서 N -> 0 으로 좋아요 개수가 변경된 것들에 대해 미갱신 문제가 발생

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-66], [WUMO-399]

[WUMO-66]: https://shoekream.atlassian.net/browse/WUMO-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-399]: https://shoekream.atlassian.net/browse/WUMO-399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ