### PR TITLE
[WUMO-400] Party 수정시 종료일 +1 이슈 해결

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -102,7 +102,7 @@ public class PartyService {
 		party.update(
 				partyUpdateRequest.name(),
 				LocalDateTime.of(partyUpdateRequest.startDate(), LocalTime.MIN),
-				LocalDateTime.of(partyUpdateRequest.endDate(), LocalTime.MAX),
+				LocalDateTime.of(partyUpdateRequest.endDate(), LocalTime.MIN),
 				partyUpdateRequest.description(),
 				partyUpdateRequest.coverImage()
 		);


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- Party 수정시 종료일 +1 이슈 해결

### ⛏ 중점 사항

- LocalTime.MAX로 들어가 DB에 23:59:59가 아닌 +1 00:00:00로 저장

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-36], [WUMO-400]

[WUMO-36]: https://shoekream.atlassian.net/browse/WUMO-36?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-400]: https://shoekream.atlassian.net/browse/WUMO-400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ