### PR TITLE
[WUMO-403] Route 상세 조회 리팩토링

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/api/RouteController.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -36,16 +35,16 @@ public class RouteController {
 	@PostMapping
 	@Operation(summary = "루트에 후보지 등록")
 	public ResponseEntity<RouteRegisterResponse> registerRoute(
-		@RequestBody @Valid RouteRegisterRequest routeRegisterRequest) {
+			@RequestBody @Valid RouteRegisterRequest routeRegisterRequest) {
 
 		return new ResponseEntity<>(routeService.registerRoute(routeRegisterRequest), HttpStatus.CREATED);
 	}
 
-	@GetMapping("/{partyId}")
+	@GetMapping("/detail")
 	@Operation(summary = "루트 상세 조회")
 	public ResponseEntity<RouteGetResponse> getRoute(
-		@PathVariable @Parameter(description = "조회할 루트가 포함된 모임 아이디") long partyId,
-		@RequestParam("path") @Parameter(description = "접근 경로(모임에서이면 0, 공개 목록에서이면 1)") int fromPublic) {
+			@RequestParam("party") @Parameter(description = "조회할 루트가 포함된 모임 아이디") long partyId,
+			@RequestParam("path") @Parameter(description = "접근 경로(모임에서이면 0, 공개 목록에서이면 1)") int fromPublic) {
 
 		return ResponseEntity.ok(routeService.getRoute(partyId, fromPublic));
 	}
@@ -53,7 +52,7 @@ public class RouteController {
 	@GetMapping
 	@Operation(summary = "공개된 루트 목록 조회")
 	public ResponseEntity<RouteGetAllResponses> getAllRoute(
-		@Valid RouteGetAllRequest routeGetAllRequest) {
+			@Valid RouteGetAllRequest routeGetAllRequest) {
 
 		return ResponseEntity.ok(routeService.getAllRoute(routeGetAllRequest));
 	}
@@ -69,7 +68,7 @@ public class RouteController {
 	@PatchMapping
 	@Operation(summary = "루트 공개여부 변경")
 	public ResponseEntity<Void> updateRoutePublicStatus(
-		@RequestBody @Valid RouteStatusUpdateRequest routeStatusUpdateRequest) {
+			@RequestBody @Valid RouteStatusUpdateRequest routeStatusUpdateRequest) {
 
 		routeService.updateRoutePublicStatus(routeStatusUpdateRequest);
 		return ResponseEntity.ok().build();

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetAllResponse.java
@@ -7,28 +7,31 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "루트 목록 조회 응답 시 각각의 루트 정보")
 public record RouteGetAllResponse(
-	@Schema(description = "루트 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
-	long routeId,
+		@Schema(description = "루트 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		long routeId,
 
-	@Schema(description = "루트의 좋아요 수", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
-	long likeCount,
+		@Schema(description = "루트의 좋아요 수", example = "10", requiredMode = Schema.RequiredMode.REQUIRED)
+		long likeCount,
 
-	@Schema(description = "로그인 중인 회원이 이 루트를 좋아요 눌렀는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
-	boolean isLiking,
+		@Schema(description = "로그인 중인 회원이 이 루트를 좋아요 눌렀는지 여부", example = "true", requiredMode = Schema.RequiredMode.REQUIRED)
+		boolean isLiking,
 
-	@Schema(description = "루트의 장소 이름들", requiredMode = Schema.RequiredMode.REQUIRED)
-	List<RouteLocationSimpleResponse> locations,
+		@Schema(description = "루트의 장소 이름들", requiredMode = Schema.RequiredMode.REQUIRED)
+		List<RouteLocationSimpleResponse> locations,
 
-	@Schema(description = "루트 이름", example = "퇴사 기념 여행", requiredMode = Schema.RequiredMode.REQUIRED)
-	String name,
+		@Schema(description = "루트 이름", example = "퇴사 기념 여행", requiredMode = Schema.RequiredMode.REQUIRED)
+		String name,
 
-	@Schema(description = "루트가 속한 모임 시작일", example = "2023-02-21T10:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-	LocalDateTime startDate,
+		@Schema(description = "루트가 속한 모임 시작일", example = "2023-02-21T10:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+		LocalDateTime startDate,
 
-	@Schema(description = "루트가 속한 모임 마지막일", example = "2023-02-25T10:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
-	LocalDateTime endDate,
+		@Schema(description = "루트가 속한 모임 마지막일", example = "2023-02-25T10:00:00", requiredMode = Schema.RequiredMode.REQUIRED)
+		LocalDateTime endDate,
 
-	@Schema(description = "루트의 썸네일 이미지", example = "https://~", requiredMode = Schema.RequiredMode.REQUIRED)
-	String image
+		@Schema(description = "루트의 썸네일 이미지", example = "https://~", requiredMode = Schema.RequiredMode.REQUIRED)
+		String image,
+
+		@Schema(description = "루트가 속한 모임 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+		Long partyId
 ) {
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetResponse.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/response/RouteGetResponse.java
@@ -9,6 +9,9 @@ public record RouteGetResponse(
 	@Schema(description = "루트 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 	Long id,
 
+	@Schema(description = "루트 이름", example = "퇴사 기념 여행", requiredMode = Schema.RequiredMode.REQUIRED)
+	String name,
+
 	@Schema(description = "루트의 현재 공개 여부", example = "false", requiredMode = Schema.RequiredMode.REQUIRED)
 	boolean isPublic,
 

--- a/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/global/mapper/RouteMapper.java
@@ -27,52 +27,54 @@ public class RouteMapper {
 		ArrayList<Location> list = new ArrayList<>();
 		list.add(location);
 		return Route.builder()
-			.locations(list)
-			.party(party)
-			.build();
+				.locations(list)
+				.party(party)
+				.build();
 	}
 
 	public static RouteGetResponse toRouteGetResponse(Route route) {
 		List<RouteLocationResponse> routeLocations = route.getLocations().stream()
-			.map(location -> new RouteLocationResponse(
-				location.getId(),
-				location.getName(),
-				location.getAddress(),
-				location.getLatitude(),
-				location.getLongitude(),
-				location.getImage(),
-				location.getDescription(),
-				location.getVisitDate(),
-				location.getExpectedCost(),
-				location.getSpending(),
-				location.getCategory().name()))
-			.toList();
-		return new RouteGetResponse(route.getId(), route.isPublic(), routeLocations, route.getParty().getId());
+				.map(location -> new RouteLocationResponse(
+						location.getId(),
+						location.getName(),
+						location.getAddress(),
+						location.getLatitude(),
+						location.getLongitude(),
+						location.getImage(),
+						location.getDescription(),
+						location.getVisitDate(),
+						location.getExpectedCost(),
+						location.getSpending(),
+						location.getCategory().name()))
+				.toList();
+		return new RouteGetResponse(route.getId(), route.getName(), route.isPublic(), routeLocations,
+				route.getParty().getId());
 	}
 
 	public static RouteGetAllResponses toRouteGetAllResponses(List<Route> routes, long lastId) {
 		List<RouteGetAllResponse> routesResponses = routes.stream()
-			.map(route -> new RouteGetAllResponse(
-				route.getId(),
-				route.getLikeCount(),
-				route.isLiking(),
-				toRouteLocationSimpleResponse(route.getLocations()),
-				route.getParty().getName(),
-				route.getParty().getStartDate(),
-				route.getParty().getEndDate(),
-				route.getParty().getCoverImage())
-			)
-			.toList();
+				.map(route -> new RouteGetAllResponse(
+						route.getId(),
+						route.getLikeCount(),
+						route.isLiking(),
+						toRouteLocationSimpleResponse(route.getLocations()),
+						route.getParty().getName(),
+						route.getParty().getStartDate(),
+						route.getParty().getEndDate(),
+						route.getParty().getCoverImage(),
+						route.getParty().getId())
+				)
+				.toList();
 		return new RouteGetAllResponses(routesResponses, lastId);
 	}
 
 	private static List<RouteLocationSimpleResponse> toRouteLocationSimpleResponse(List<Location> locations) {
 		return locations.stream()
-			.map(location -> new RouteLocationSimpleResponse(
-				location.getId(),
-				location.getName(),
-				location.getAddress(),
-				location.getImage()
-			)).toList();
+				.map(location -> new RouteLocationSimpleResponse(
+						location.getId(),
+						location.getName(),
+						location.getAddress(),
+						location.getImage()
+				)).toList();
 	}
 }

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -144,7 +144,8 @@ public class RouteControllerTest extends MysqlTestContainer {
 	void get_route_in_party() throws Exception {
 		//when
 		ResultActions resultActions
-				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/{partyId}", partyId)
+				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/detail")
+				.param("party", String.valueOf(partyId))
 				.param("path", "0"));
 
 		//then
@@ -162,7 +163,8 @@ public class RouteControllerTest extends MysqlTestContainer {
 	void get_route_from_public_list() throws Exception {
 		//when
 		ResultActions resultActions
-				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/{partyId}", partyId)
+				= mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/routes/detail")
+				.param("party", String.valueOf(partyId))
 				.param("path", "1"));
 
 		//then


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 루트 상세 조회 end point에서 partyId를 path variable -> request param으로 받도록 수정
해당 도메인의 아이디가 아니기 때문에 partyId를 명시하도록 request param으로 변경했습니다
- 루트 상세 조회 응답시, 루트 이름 데이터도 가도록 수정

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 특이사항은 없습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-404], [WUMO-405]

[WUMO-404]: https://shoekream.atlassian.net/browse/WUMO-404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-405]: https://shoekream.atlassian.net/browse/WUMO-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ