### PR TITLE
[WUMO-409] Route에 후보지 등록 기능 리팩토링

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteRegisterRequest.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/dto/request/RouteRegisterRequest.java
@@ -6,9 +6,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(name = "루트에 후보지 등록 요청 정보")
 public record RouteRegisterRequest(
-	@Schema(description = "이미 루트가 존재할 경우의 루트 식별자(루트를 처음 생성한다면 null)", example = "1", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-	Long routeId,
-
 	@NotNull(message = "등록할 후보지를 선택해주세요.")
 	@Schema(description = "루트에 등록할 후보지 식별자", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
 	Long locationId,

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -46,17 +46,13 @@ public class RouteService {
 
 	@Transactional
 	public RouteRegisterResponse registerRoute(RouteRegisterRequest routeRegisterRequest) {
-		Party party = getPartyEntity(routeRegisterRequest.partyId());
+		long partyId = routeRegisterRequest.partyId();
+		Party party = getPartyEntity(partyId);
 		Location location = getLocationEntity(routeRegisterRequest.locationId());
-		validateAccess(party.getId());
+		validateAccess(partyId);
 
-		if (routeRegisterRequest.routeId() == null) {
-			Route route = routeRepository.save(toRoute(location, party));
-			route.updateLocation(location);
-			return toRouteRegisterResponse(route.getId());
-		}
-
-		Route route = getRouteEntity(routeRegisterRequest.routeId());
+		Route route = routeRepository.findByPartyId(partyId)
+				.orElseGet(() -> routeRepository.save(toRoute(location, party)));
 		route.updateLocation(location);
 
 		return toRouteRegisterResponse(route.getId());

--- a/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/api/RouteControllerTest.java
@@ -124,7 +124,7 @@ public class RouteControllerTest extends MysqlTestContainer {
 	void register_route() throws Exception {
 		//given
 		RouteRegisterRequest routeRegisterRequest
-				= new RouteRegisterRequest(null, locationId, partyId);
+				= new RouteRegisterRequest(locationId, partyId);
 
 		//when
 		ResultActions resultActions

--- a/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/route/service/RouteServiceTest.java
@@ -100,10 +100,10 @@ public class RouteServiceTest {
 		void success_not_first_register() {
 			//given
 			RouteRegisterRequest routeRegisterRequest
-					= new RouteRegisterRequest(routeId, locationId, partyId);
+					= new RouteRegisterRequest(locationId, partyId);
 
 			//mocking
-			given(routeRepository.findById(anyLong()))
+			given(routeRepository.findByPartyId(anyLong()))
 					.willReturn(Optional.of(route));
 			given(partyRepository.findById(anyLong()))
 					.willReturn(Optional.of(party));
@@ -119,7 +119,7 @@ public class RouteServiceTest {
 			assertThat(routeRegisterResponse.id()).isEqualTo(routeId);
 			then(routeRepository)
 					.should()
-					.findById(anyLong());
+					.findByPartyId(anyLong());
 		}
 
 		@Test
@@ -127,7 +127,7 @@ public class RouteServiceTest {
 		void success_first_register() {
 			//given
 			RouteRegisterRequest routeRegisterRequest
-					= new RouteRegisterRequest(null, locationId, partyId);
+					= new RouteRegisterRequest(locationId, partyId);
 
 			//mocking
 			given(routeRepository.save(any(Route.class)))
@@ -154,7 +154,7 @@ public class RouteServiceTest {
 		void fail_not_party_member() {
 			//given
 			RouteRegisterRequest routeRegisterRequest
-					= new RouteRegisterRequest(routeId, locationId, partyId);
+					= new RouteRegisterRequest(locationId, partyId);
 
 			//mocking
 			given(partyRepository.findById(anyLong()))


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 루트에 후보지 등록 요청 시, 프론트에서 상황에 따라 루트 식별자를 추출하기 어려운 경우가 있어
루트 식별자가 아닌 모임 식별자로 요청하도록 수정하였습니다

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 특이사항은 없습니다

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-410], [WUMO-411]

[WUMO-410]: https://shoekream.atlassian.net/browse/WUMO-410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WUMO-411]: https://shoekream.atlassian.net/browse/WUMO-411?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ