### PR TITLE
[WUMO-416] Mapper 패키지 구조 수정

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/mapper/CommentMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.comment.mapper;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/LocationCommentService.java
@@ -1,10 +1,10 @@
 package org.prgrms.wumo.domain.comment.service;
 
 import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationComment;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationCommentGetAllResponse;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationCommentRegisterResponse;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationCommentUpdateResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toLocationComment;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toLocationCommentGetAllResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toLocationCommentRegisterResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toLocationCommentUpdateResponse;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentService.java
@@ -1,10 +1,10 @@
 package org.prgrms.wumo.domain.comment.service;
 
 import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteComment;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentGetAllResponse;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentRegisterResponse;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentUpdateResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toPartyRouteComment;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toPartyRouteCommentGetAllResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toPartyRouteCommentRegisterResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toPartyRouteCommentUpdateResponse;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/org/prgrms/wumo/domain/comment/service/ReplyCommentService.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/service/ReplyCommentService.java
@@ -3,9 +3,9 @@ package org.prgrms.wumo.domain.comment.service;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.COMMENT;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.WRONG_ACCESS;
 import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toReplyComment;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toReplyCommentGetAllResponse;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toReplyCommentRegisterResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toReplyComment;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toReplyCommentGetAllResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toReplyCommentRegisterResponse;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.ENTITY_NOT_FOUND;
 
 

--- a/src/main/java/org/prgrms/wumo/domain/image/mapper/ImageMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/mapper/ImageMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.image.mapper;
 
 import org.prgrms.wumo.domain.image.dto.response.ImageRegisterResponse;
 

--- a/src/main/java/org/prgrms/wumo/domain/image/service/ImageService.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/service/ImageService.java
@@ -1,6 +1,6 @@
 package org.prgrms.wumo.domain.image.service;
 
-import static org.prgrms.wumo.global.mapper.ImageMapper.toImageRegisterResponse;
+import static org.prgrms.wumo.domain.image.mapper.ImageMapper.toImageRegisterResponse;
 
 import org.prgrms.wumo.domain.image.dto.request.ImageDeleteRequest;
 import org.prgrms.wumo.domain.image.dto.request.ImageRegisterRequest;

--- a/src/main/java/org/prgrms/wumo/domain/like/mapper/LikeMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/mapper/LikeMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.like.mapper;
 
 import org.prgrms.wumo.domain.like.model.RouteLike;
 import org.prgrms.wumo.domain.member.model.Member;

--- a/src/main/java/org/prgrms/wumo/domain/like/service/RouteLikeService.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/service/RouteLikeService.java
@@ -3,7 +3,7 @@ package org.prgrms.wumo.domain.like.service;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.ENTITY_NOT_FOUND;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.MEMBER;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.ROUTE;
-import static org.prgrms.wumo.global.mapper.LikeMapper.toRouteLike;
+import static org.prgrms.wumo.domain.like.mapper.LikeMapper.toRouteLike;
 
 import javax.persistence.EntityNotFoundException;
 

--- a/src/main/java/org/prgrms/wumo/domain/location/mapper/LocationMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/mapper/LocationMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.location.mapper;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/service/LocationService.java
@@ -1,12 +1,12 @@
 package org.prgrms.wumo.domain.location.service;
 
 import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocation;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetAllResponse;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationRegisterResponse;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationSpendingUpdateResponse;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationUpdateResponse;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocation;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocationGetAllResponse;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocationGetResponse;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocationRegisterResponse;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocationSpendingUpdateResponse;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocationUpdateResponse;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/org/prgrms/wumo/domain/member/mapper/MemberMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/mapper/MemberMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.member.mapper;
 
 import org.prgrms.wumo.domain.member.dto.request.MemberRegisterRequest;
 import org.prgrms.wumo.domain.member.dto.response.MemberGetResponse;

--- a/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/member/service/MemberService.java
@@ -2,10 +2,10 @@ package org.prgrms.wumo.domain.member.service;
 
 import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
 import static org.prgrms.wumo.global.jwt.JwtUtil.isValidAccess;
-import static org.prgrms.wumo.global.mapper.MemberMapper.toMember;
-import static org.prgrms.wumo.global.mapper.MemberMapper.toMemberGetResponse;
-import static org.prgrms.wumo.global.mapper.MemberMapper.toMemberLoginResponse;
-import static org.prgrms.wumo.global.mapper.MemberMapper.toMemberRegisterResponse;
+import static org.prgrms.wumo.domain.member.mapper.MemberMapper.toMember;
+import static org.prgrms.wumo.domain.member.mapper.MemberMapper.toMemberGetResponse;
+import static org.prgrms.wumo.domain.member.mapper.MemberMapper.toMemberLoginResponse;
+import static org.prgrms.wumo.domain.member.mapper.MemberMapper.toMemberRegisterResponse;
 
 import javax.persistence.EntityNotFoundException;
 

--- a/src/main/java/org/prgrms/wumo/domain/party/mapper/PartyMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/mapper/PartyMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.party.mapper;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/src/main/java/org/prgrms/wumo/domain/party/service/InvitationService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/InvitationService.java
@@ -1,7 +1,7 @@
 package org.prgrms.wumo.domain.party.service;
 
-import static org.prgrms.wumo.global.mapper.PartyMapper.toInvitationRegisterResponse;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toInvitationValidateResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toInvitationRegisterResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toInvitationValidateResponse;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyMemberService.java
@@ -3,9 +3,9 @@ package org.prgrms.wumo.domain.party.service;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.ENTITY_NOT_FOUND;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.MEMBER;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.PARTY;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyMember;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyMemberGetAllResponse;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyMemberGetResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyMember;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyMemberGetAllResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyMemberGetResponse;
 
 import java.util.List;
 import java.util.Objects;

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -3,11 +3,11 @@ package org.prgrms.wumo.domain.party.service;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.ENTITY_NOT_FOUND;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.MEMBER;
 import static org.prgrms.wumo.global.exception.ExceptionMessage.PARTY;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toParty;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetAllResponse;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyGetDetailResponse;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyMember;
-import static org.prgrms.wumo.global.mapper.PartyMapper.toPartyRegisterResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toParty;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyGetAllResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyGetDetailResponse;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyMember;
+import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyRegisterResponse;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;

--- a/src/main/java/org/prgrms/wumo/domain/route/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/mapper/RouteMapper.java
@@ -1,4 +1,4 @@
-package org.prgrms.wumo.global.mapper;
+package org.prgrms.wumo.domain.route.mapper;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/main/java/org/prgrms/wumo/domain/route/mapper/RouteMapper.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/mapper/RouteMapper.java
@@ -45,10 +45,16 @@ public class RouteMapper {
 						location.getVisitDate(),
 						location.getExpectedCost(),
 						location.getSpending(),
-						location.getCategory().name()))
+						location.getCategory().name())
+				)
 				.toList();
-		return new RouteGetResponse(route.getId(), route.getName(), route.isPublic(), routeLocations,
-				route.getParty().getId(), route.isLiking());
+		return new RouteGetResponse(
+				route.getId(),
+				route.getName(),
+				route.isPublic(),
+				routeLocations,
+				route.getParty().getId(),
+				route.isLiking());
 	}
 
 	public static RouteGetAllResponses toRouteGetAllResponses(List<Route> routes, long lastId) {
@@ -74,7 +80,8 @@ public class RouteMapper {
 						location.getId(),
 						location.getName(),
 						location.getAddress(),
-						location.getImage()
-				)).toList();
+						location.getImage())
+				)
+				.toList();
 	}
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -1,10 +1,10 @@
 package org.prgrms.wumo.domain.route.service;
 
 import static org.prgrms.wumo.global.jwt.JwtUtil.getMemberId;
-import static org.prgrms.wumo.global.mapper.RouteMapper.toRoute;
-import static org.prgrms.wumo.global.mapper.RouteMapper.toRouteGetAllResponses;
-import static org.prgrms.wumo.global.mapper.RouteMapper.toRouteGetResponse;
-import static org.prgrms.wumo.global.mapper.RouteMapper.toRouteRegisterResponse;
+import static org.prgrms.wumo.domain.route.mapper.RouteMapper.toRoute;
+import static org.prgrms.wumo.domain.route.mapper.RouteMapper.toRouteGetAllResponses;
+import static org.prgrms.wumo.domain.route.mapper.RouteMapper.toRouteGetResponse;
+import static org.prgrms.wumo.domain.route.mapper.RouteMapper.toRouteRegisterResponse;
 
 import java.util.List;
 

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/LocationCommentServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toLocationCommentGetAllResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toLocationCommentGetAllResponse;
 
 import java.time.LocalDateTime;
 import java.util.Collections;

--- a/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/comment/service/PartyRouteCommentServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.prgrms.wumo.global.mapper.CommentMapper.toPartyRouteCommentGetAllResponse;
+import static org.prgrms.wumo.domain.comment.mapper.CommentMapper.toPartyRouteCommentGetAllResponse;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;

--- a/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/location/service/LocationServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.prgrms.wumo.global.mapper.LocationMapper.toLocationGetResponse;
+import static org.prgrms.wumo.domain.location.mapper.LocationMapper.toLocationGetResponse;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 도메인별 mapper 해당 도메인 하위로 패키지 변경

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 팀 회의 결과 mapper를 해당 도메인에서만 사용하기 때문에 global로 빼는것은 불필요하다고 판단하여
해당 도메인 하위로 패키지 수정하였습니다
- 개인적인 생각은 위와 같은 이유로 static keyword가 필요할까 의문이 듭니다
다들 어떻게 생각하시나요??

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-417]

[WUMO-417]: https://shoekream.atlassian.net/browse/WUMO-417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ