### PR TITLE
[WUMO-425] RouteLike 등록 동시성 이슈 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 
     //Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.redisson:redisson-spring-boot-starter:3.20.0'
 
     //Mail
     implementation 'org.springframework.boot:spring-boot-starter-mail'

--- a/src/main/java/org/prgrms/wumo/batch/like/RouteLikeBatchComponent.java
+++ b/src/main/java/org/prgrms/wumo/batch/like/RouteLikeBatchComponent.java
@@ -14,9 +14,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class RouteLikeBatchComponent {
 
-	private static final int BATCH_FREQUENCY = 600000; 	// MilliSeconds
+	private static final int BATCH_FREQUENCY = 60000; // MilliSeconds
 
-	private static final int BATCH_SIZE = 1000;					// COUNT Record Result Size
+	private static final int BATCH_SIZE = 1000; // COUNT Record Result Size
 
 	private final RouteLikeRepository routeLikeRepository;
 


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- RouteLike 등록 동시성 이슈 해결

### ⛏ 중점 사항

- Redisson 분산 락을 활용 -> 특정 루트와 사용자 (ex. "500 150") 를 키로 갖는 락을 점유하여 동시성 이슈 해결
- @Transactional 사용이 불가능하기 때문에 직접 Transaction 제어
- 동시성 이슈를 점검했던 코드의 일부는 여러 테스트에 영향을 줄 수 있어 따로 올리지 않고 아래에 포함하겠습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-425]

```java
@Test
void syncTest() throws InterruptedException {
int threadCount = 10;
ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
CountDownLatch latch = new CountDownLatch(threadCount);

for (int i = 0; i < threadCount; i++) {
	executorService.execute(() -> {
		try {
			setAuthentication(member.getId());
			routeLikeService.registerRouteLike(route.getId());
		} catch (DuplicateException e) {
			System.out.println("e = " + e);
		}	finally {
			latch.countDown();
		}});
}
latch.await();

List<Pair<Long, Long>> pairs = routeLikeRepository.countAllByRouteId(null, 1);
System.out.println("pairs = " + pairs);

assertEquals(route.getId(), pairs.get(0).getFirst());
assertEquals(1L, pairs.get(0).getSecond());
}
```

[WUMO-425]: https://shoekream.atlassian.net/browse/WUMO-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ