### PR TITLE
[WUMO-434] 전체 도메인 삭제 이벤트 처리

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/comment/listener/LocationCommentListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/listener/LocationCommentListener.java
@@ -16,7 +16,7 @@ public class LocationCommentListener implements JpaEventListener, PostDeleteEven
 	private static LocationCommentRepository locationCommentRepository;
 
 	@Autowired
-	public void setInvitationRepository(LocationCommentRepository locationCommentRepository) {
+	public void setLocationCommentRepository(LocationCommentRepository locationCommentRepository) {
 		LocationCommentListener.locationCommentRepository = locationCommentRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/listener/LocationCommentListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/listener/LocationCommentListener.java
@@ -1,0 +1,42 @@
+package org.prgrms.wumo.domain.comment.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.comment.repository.LocationCommentRepository;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationCommentListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static LocationCommentRepository locationCommentRepository;
+
+	@Autowired
+	public void setInvitationRepository(LocationCommentRepository locationCommentRepository) {
+		LocationCommentListener.locationCommentRepository = locationCommentRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof Location location) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> locationCommentRepository.deleteAllByLocationId(location.getId()));
+				}
+			}));
+		}
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/listener/PartyRouteCommentListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/listener/PartyRouteCommentListener.java
@@ -18,7 +18,7 @@ public class PartyRouteCommentListener implements JpaEventListener, PostDeleteEv
 	private static PartyRouteCommentRepository partyRouteCommentRepository;
 
 	@Autowired
-	public void setInvitationRepository(PartyRouteCommentRepository partyRouteCommentRepository) {
+	public void setPartyRouteCommentRepository(PartyRouteCommentRepository partyRouteCommentRepository) {
 		PartyRouteCommentListener.partyRouteCommentRepository = partyRouteCommentRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/listener/PartyRouteCommentListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/listener/PartyRouteCommentListener.java
@@ -1,0 +1,59 @@
+package org.prgrms.wumo.domain.comment.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.comment.repository.PartyRouteCommentRepository;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.party.model.PartyMember;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartyRouteCommentListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static PartyRouteCommentRepository partyRouteCommentRepository;
+
+	@Autowired
+	public void setInvitationRepository(PartyRouteCommentRepository partyRouteCommentRepository) {
+		PartyRouteCommentListener.partyRouteCommentRepository = partyRouteCommentRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof Location location) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session ->
+							partyRouteCommentRepository.deleteAllByLocationId(location.getId()));
+				}
+			}));
+		} else if (entity instanceof Route route) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session ->
+							partyRouteCommentRepository.deleteAllByRouteId(route.getId()));
+				}
+			}));
+		} else if (entity instanceof PartyMember partyMember) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session ->
+							partyRouteCommentRepository.deleteAllByPartyMemberId(partyMember.getId()));
+				}
+			}));
+		}
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/listener/ReplyCommentListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/listener/ReplyCommentListener.java
@@ -1,0 +1,42 @@
+package org.prgrms.wumo.domain.comment.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.comment.model.Comment;
+import org.prgrms.wumo.domain.comment.repository.ReplyCommentRepository;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReplyCommentListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static ReplyCommentRepository replyCommentRepository;
+
+	@Autowired
+	public void setInvitationRepository(ReplyCommentRepository replyCommentRepository) {
+		ReplyCommentListener.replyCommentRepository = replyCommentRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof Comment comment) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> replyCommentRepository.deleteAllByCommentId(comment.getId()));
+				}
+			}));
+		}
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/comment/listener/ReplyCommentListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/listener/ReplyCommentListener.java
@@ -16,7 +16,7 @@ public class ReplyCommentListener implements JpaEventListener, PostDeleteEventLi
 	private static ReplyCommentRepository replyCommentRepository;
 
 	@Autowired
-	public void setInvitationRepository(ReplyCommentRepository replyCommentRepository) {
+	public void setReplyCommentRepository(ReplyCommentRepository replyCommentRepository) {
 		ReplyCommentListener.replyCommentRepository = replyCommentRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/comment/repository/LocationCommentRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/repository/LocationCommentRepository.java
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationCommentRepository extends JpaRepository<LocationComment, Long>, LocationCommentCustomRepository {
+
+	void deleteAllByLocationId(Long locationId);
+
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/repository/PartyRouteCommentRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/repository/PartyRouteCommentRepository.java
@@ -2,6 +2,17 @@ package org.prgrms.wumo.domain.comment.repository;
 
 import org.prgrms.wumo.domain.comment.model.PartyRouteComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PartyRouteCommentRepository extends JpaRepository<PartyRouteComment, Long>, PartyRouteCommentCustomRepository {
+
+	void deleteAllByLocationId(Long locationId);
+
+	void deleteAllByRouteId(Long routeId);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM PartyRouteComment c WHERE c.partyMember.id = :partyMemberId")
+	void deleteAllByPartyMemberId(Long partyMemberId);
+
 }

--- a/src/main/java/org/prgrms/wumo/domain/comment/repository/ReplyCommentRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/comment/repository/ReplyCommentRepository.java
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReplyCommentRepository extends JpaRepository<ReplyComment, Long>, ReplyCommentCustomRepository {
+
+	void deleteAllByCommentId(Long commentId);
+
 }

--- a/src/main/java/org/prgrms/wumo/domain/image/listener/ImageListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/listener/ImageListener.java
@@ -1,0 +1,63 @@
+package org.prgrms.wumo.domain.image.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.comment.model.Comment;
+import org.prgrms.wumo.domain.image.repository.ImageRepository;
+import org.prgrms.wumo.domain.location.model.Location;
+import org.prgrms.wumo.domain.member.model.Member;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ImageListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static ImageRepository imageRepository;
+
+	@Autowired
+	public void setInvitationRepository(ImageRepository imageRepository) {
+		ImageListener.imageRepository = imageRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof Member member) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> imageRepository.delete(member.getProfileImage()));
+				}
+			}));
+		} else if (entity instanceof Party party) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> imageRepository.delete(party.getCoverImage()));
+				}
+			}));
+		} else if (entity instanceof Location location) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> imageRepository.delete(location.getImage()));
+				}
+			}));
+		} else if (entity instanceof Comment comment) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> imageRepository.delete(comment.getImage()));
+				}
+			}));
+		}
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/image/repository/ImageRepository.java
@@ -58,6 +58,10 @@ public class ImageRepository {
 	}
 
 	public void delete(String imageUrl) {
+		if (imageUrl == null || imageUrl.isBlank()) {
+			return;
+		}
+
 		try {
 			String imageUrlWithHost = removeProtocols(imageUrl);
 			validateHost(imageUrlWithHost);

--- a/src/main/java/org/prgrms/wumo/domain/like/listener/RouteLikeListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/listener/RouteLikeListener.java
@@ -1,0 +1,44 @@
+package org.prgrms.wumo.domain.like.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.like.repository.RouteLikeRepository;
+import org.prgrms.wumo.domain.route.model.Route;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RouteLikeListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static RouteLikeRepository routeLikeRepository;
+
+	@Autowired
+	public void setInvitationRepository(RouteLikeRepository routeLikeRepository) {
+		RouteLikeListener.routeLikeRepository = routeLikeRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+		if (!(entity instanceof Route route)) {
+			return;
+		}
+
+		event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+			if (success) {
+				commitOrRollback(sessionImplementor, session -> routeLikeRepository.deleteAllByRouteId(route.getId()));
+			}
+		}));
+
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/like/listener/RouteLikeListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/listener/RouteLikeListener.java
@@ -16,7 +16,7 @@ public class RouteLikeListener implements JpaEventListener, PostDeleteEventListe
 	private static RouteLikeRepository routeLikeRepository;
 
 	@Autowired
-	public void setInvitationRepository(RouteLikeRepository routeLikeRepository) {
+	public void setRouteLikeRepository(RouteLikeRepository routeLikeRepository) {
 		RouteLikeListener.routeLikeRepository = routeLikeRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/like/repository/RouteLikeRepository.java
@@ -10,6 +10,10 @@ public interface RouteLikeRepository extends JpaRepository<RouteLike, Long>, Rou
 	boolean existsByRouteIdAndMemberId(Long routeId, Long memberId);
 
 	@Modifying
+	@Query("DELETE FROM RouteLike routeLike WHERE routeLike.routeId = :routeId")
+	void deleteAllByRouteId(Long routeId);
+
+	@Modifying
 	@Query("DELETE FROM RouteLike routeLike WHERE routeLike.routeId = :routeId AND routeLike.memberId = :memberId")
 	int deleteByRouteIdAndMemberId(Long routeId, Long memberId);
 

--- a/src/main/java/org/prgrms/wumo/domain/location/listener/LocationListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/listener/LocationListener.java
@@ -1,0 +1,42 @@
+package org.prgrms.wumo.domain.location.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.location.repository.LocationRepository;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LocationListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static LocationRepository locationRepository;
+
+	@Autowired
+	public void setInvitationRepository(LocationRepository locationRepository) {
+		LocationListener.locationRepository = locationRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+
+		if (entity instanceof Party party) {
+			event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+				if (success) {
+					commitOrRollback(sessionImplementor, session -> locationRepository.deleteAllByPartyId(party.getId()));
+				}
+			}));
+		}
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/location/listener/LocationListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/listener/LocationListener.java
@@ -16,7 +16,7 @@ public class LocationListener implements JpaEventListener, PostDeleteEventListen
 	private static LocationRepository locationRepository;
 
 	@Autowired
-	public void setInvitationRepository(LocationRepository locationRepository) {
+	public void setLocationRepository(LocationRepository locationRepository) {
 		LocationListener.locationRepository = locationRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/location/repository/LocationRepository.java
@@ -6,4 +6,7 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LocationRepository extends JpaRepository<Location, Long>, LocationCustomRepository {
+
+	void deleteAllByPartyId(Long partyId);
+
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/listener/InvitationListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/listener/InvitationListener.java
@@ -1,0 +1,44 @@
+package org.prgrms.wumo.domain.party.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.repository.InvitationRepository;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InvitationListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static InvitationRepository invitationRepository;
+
+	@Autowired
+	public void setInvitationRepository(InvitationRepository invitationRepository) {
+		InvitationListener.invitationRepository = invitationRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+		if (!(entity instanceof Party party)) {
+			return;
+		}
+
+		event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+			if (success) {
+				commitOrRollback(sessionImplementor, session -> invitationRepository.deleteAllByPartyId(party.getId()));
+			}
+		}));
+
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/party/listener/PartyMemberListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/listener/PartyMemberListener.java
@@ -1,0 +1,44 @@
+package org.prgrms.wumo.domain.party.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PartyMemberListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static PartyMemberRepository partyMemberRepository;
+
+	@Autowired
+	public void setInvitationRepository(PartyMemberRepository partyMemberRepository) {
+		PartyMemberListener.partyMemberRepository = partyMemberRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+		if (!(entity instanceof Party party)) {
+			return;
+		}
+
+		event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+			if (success) {
+				commitOrRollback(sessionImplementor, session -> partyMemberRepository.deleteAllByPartyId(party.getId()));
+			}
+		}));
+
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/party/listener/PartyMemberListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/listener/PartyMemberListener.java
@@ -16,7 +16,7 @@ public class PartyMemberListener implements JpaEventListener, PostDeleteEventLis
 	private static PartyMemberRepository partyMemberRepository;
 
 	@Autowired
-	public void setInvitationRepository(PartyMemberRepository partyMemberRepository) {
+	public void setPartyMemberRepository(PartyMemberRepository partyMemberRepository) {
 		PartyMemberListener.partyMemberRepository = partyMemberRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/InvitationRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/InvitationRepository.java
@@ -5,11 +5,15 @@ import java.util.Optional;
 import org.prgrms.wumo.domain.party.model.Invitation;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface InvitationRepository extends JpaRepository<Invitation, Long> {
 
 	Optional<Invitation> findTopByPartyOrderByIdDesc(Party party);
 
-	void deleteAllByParty(Party party);
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Invitation i WHERE i.party.id = :partyId")
+	void deleteAllByPartyId(Long partyId);
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/repository/PartyMemberRepository.java
@@ -3,9 +3,15 @@ package org.prgrms.wumo.domain.party.repository;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface PartyMemberRepository extends JpaRepository<PartyMember, Long>, PartyMemberCustomRepository {
 
 	long countAllByParty(Party party);
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM PartyMember pm WHERE pm.party.id = :partyId")
+	void deleteAllByPartyId(Long partyId);
 
 }

--- a/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
+++ b/src/main/java/org/prgrms/wumo/domain/party/service/PartyService.java
@@ -1,13 +1,13 @@
 package org.prgrms.wumo.domain.party.service;
 
-import static org.prgrms.wumo.global.exception.ExceptionMessage.ENTITY_NOT_FOUND;
-import static org.prgrms.wumo.global.exception.ExceptionMessage.MEMBER;
-import static org.prgrms.wumo.global.exception.ExceptionMessage.PARTY;
 import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toParty;
 import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyGetAllResponse;
 import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyGetDetailResponse;
 import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyMember;
 import static org.prgrms.wumo.domain.party.mapper.PartyMapper.toPartyRegisterResponse;
+import static org.prgrms.wumo.global.exception.ExceptionMessage.ENTITY_NOT_FOUND;
+import static org.prgrms.wumo.global.exception.ExceptionMessage.MEMBER;
+import static org.prgrms.wumo.global.exception.ExceptionMessage.PARTY;
 
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -16,7 +16,6 @@ import java.util.Objects;
 
 import javax.persistence.EntityNotFoundException;
 
-import org.prgrms.wumo.domain.image.repository.ImageRepository;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyGetRequest;
@@ -27,7 +26,6 @@ import org.prgrms.wumo.domain.party.dto.response.PartyGetResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
-import org.prgrms.wumo.domain.party.repository.InvitationRepository;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.party.repository.PartyRepository;
 import org.prgrms.wumo.global.exception.custom.PartyNotEmptyException;
@@ -47,10 +45,6 @@ public class PartyService {
 	private final PartyRepository partyRepository;
 
 	private final PartyMemberRepository partyMemberRepository;
-
-	private final InvitationRepository invitationRepository;
-
-	private final ImageRepository imageRepository;
 
 	@Transactional
 	public PartyRegisterResponse registerParty(PartyRegisterRequest partyRegisterRequest) {
@@ -119,9 +113,6 @@ public class PartyService {
 		// 모임장인 경우 모임에 멤버가 본인을 제외하고 없어야만 삭제 가능
 		List<PartyMember> partyMembers = partyMemberRepository.findAllByPartyId(partyId, null, 2);
 		if (partyMembers.size() == 1 && Objects.equals(partyMembers.get(0).getId(), partyLeader.getId())) {
-			imageRepository.delete(partyLeader.getParty().getCoverImage());
-			invitationRepository.deleteAllByParty(partyLeader.getParty());
-			partyMemberRepository.delete(partyLeader);
 			partyRepository.deleteById(partyId);
 		} else {
 			throw new PartyNotEmptyException("본인을 제외하고 모임에 가입된 회원이 없어야 합니다.");

--- a/src/main/java/org/prgrms/wumo/domain/route/listener/RouteListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/listener/RouteListener.java
@@ -1,0 +1,44 @@
+package org.prgrms.wumo.domain.route.listener;
+
+import org.hibernate.event.spi.PostDeleteEvent;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.persister.entity.EntityPersister;
+import org.prgrms.wumo.domain.party.model.Party;
+import org.prgrms.wumo.domain.route.repository.RouteRepository;
+import org.prgrms.wumo.global.event.listener.JpaEventListener;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RouteListener implements JpaEventListener, PostDeleteEventListener {
+
+	private static RouteRepository routeRepository;
+
+	@Autowired
+	public void setInvitationRepository(RouteRepository routeRepository) {
+		RouteListener.routeRepository = routeRepository;
+	}
+
+	@Async
+	@Override
+	public void onPostDelete(PostDeleteEvent event) {
+		Object entity = event.getEntity();
+		if (!(entity instanceof Party party)) {
+			return;
+		}
+
+		event.getSession().getActionQueue().registerProcess(((success, sessionImplementor) -> {
+			if (success) {
+				commitOrRollback(sessionImplementor, session -> routeRepository.deleteAllByPartyId(party.getId()));
+			}
+		}));
+
+	}
+
+	@Override
+	public boolean requiresPostCommitHanding(EntityPersister persister) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/domain/route/listener/RouteListener.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/listener/RouteListener.java
@@ -16,7 +16,7 @@ public class RouteListener implements JpaEventListener, PostDeleteEventListener 
 	private static RouteRepository routeRepository;
 
 	@Autowired
-	public void setInvitationRepository(RouteRepository routeRepository) {
+	public void setRouteRepository(RouteRepository routeRepository) {
 		RouteListener.routeRepository = routeRepository;
 	}
 

--- a/src/main/java/org/prgrms/wumo/domain/route/repository/RouteRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/repository/RouteRepository.java
@@ -2,6 +2,13 @@ package org.prgrms.wumo.domain.route.repository;
 
 import org.prgrms.wumo.domain.route.model.Route;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface RouteRepository extends JpaRepository<Route, Long>, RouteCustomRepository {
+
+	@Modifying(clearAutomatically = true)
+	@Query("DELETE FROM Route r WHERE r.party.id = :partyId")
+	void deleteAllByPartyId(Long partyId);
+
 }

--- a/src/main/java/org/prgrms/wumo/global/event/listener/EventListenerIntegrator.java
+++ b/src/main/java/org/prgrms/wumo/global/event/listener/EventListenerIntegrator.java
@@ -6,10 +6,15 @@ import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.prgrms.wumo.domain.comment.listener.LocationCommentListener;
+import org.prgrms.wumo.domain.comment.listener.PartyRouteCommentListener;
+import org.prgrms.wumo.domain.comment.listener.ReplyCommentListener;
 import org.prgrms.wumo.domain.image.listener.ImageListener;
 import org.prgrms.wumo.domain.like.listener.RouteLikeListener;
+import org.prgrms.wumo.domain.location.listener.LocationListener;
 import org.prgrms.wumo.domain.party.listener.InvitationListener;
 import org.prgrms.wumo.domain.party.listener.PartyMemberListener;
+import org.prgrms.wumo.domain.route.listener.RouteListener;
 
 public class EventListenerIntegrator implements Integrator {
 
@@ -25,7 +30,12 @@ public class EventListenerIntegrator implements Integrator {
 						new ImageListener(),
 						new InvitationListener(),
 						new PartyMemberListener(),
-						new RouteLikeListener()
+						new RouteLikeListener(),
+						new LocationListener(),
+						new RouteListener(),
+						new LocationCommentListener(),
+						new PartyRouteCommentListener(),
+						new ReplyCommentListener()
 				);
 	}
 

--- a/src/main/java/org/prgrms/wumo/global/event/listener/EventListenerIntegrator.java
+++ b/src/main/java/org/prgrms/wumo/global/event/listener/EventListenerIntegrator.java
@@ -1,0 +1,37 @@
+package org.prgrms.wumo.global.event.listener;
+
+import org.hibernate.boot.Metadata;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.integrator.spi.Integrator;
+import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.prgrms.wumo.domain.image.listener.ImageListener;
+import org.prgrms.wumo.domain.like.listener.RouteLikeListener;
+import org.prgrms.wumo.domain.party.listener.InvitationListener;
+import org.prgrms.wumo.domain.party.listener.PartyMemberListener;
+
+public class EventListenerIntegrator implements Integrator {
+
+	@Override
+	public void integrate(
+			Metadata metadata,
+			SessionFactoryImplementor sessionFactory,
+			SessionFactoryServiceRegistry serviceRegistry
+	) {
+		EventListenerRegistry eventListenerRegistry = serviceRegistry.getService(EventListenerRegistry.class);
+		eventListenerRegistry.getEventListenerGroup(EventType.POST_DELETE)
+				.appendListeners(
+						new ImageListener(),
+						new InvitationListener(),
+						new PartyMemberListener(),
+						new RouteLikeListener()
+				);
+	}
+
+	@Override
+	public void disintegrate(SessionFactoryImplementor sessionFactory, SessionFactoryServiceRegistry serviceRegistry) {
+
+	}
+
+}

--- a/src/main/java/org/prgrms/wumo/global/event/listener/JpaEventListener.java
+++ b/src/main/java/org/prgrms/wumo/global/event/listener/JpaEventListener.java
@@ -1,0 +1,27 @@
+package org.prgrms.wumo.global.event.listener;
+
+import java.util.function.Consumer;
+
+import org.hibernate.Transaction;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+public interface JpaEventListener {
+
+	default void commitOrRollback(
+			SharedSessionContractImplementor session,
+			Consumer<SharedSessionContractImplementor> task
+	) {
+		Transaction tx = null;
+		try {
+			tx = session.beginTransaction();
+			task.accept(session);
+			tx.commit();
+		} catch (RuntimeException ex) {
+			if (tx != null) {
+				tx.rollback();
+			}
+			throw ex;
+		}
+	}
+
+}

--- a/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
+++ b/src/main/resources/META-INF/services/org.hibernate.integrator.spi.Integrator
@@ -1,0 +1,1 @@
+org.prgrms.wumo.global.event.listener.EventListenerIntegrator

--- a/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
+++ b/src/test/java/org/prgrms/wumo/domain/party/service/PartyServiceTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.prgrms.wumo.domain.image.repository.ImageRepository;
 import org.prgrms.wumo.domain.member.model.Member;
 import org.prgrms.wumo.domain.member.repository.MemberRepository;
 import org.prgrms.wumo.domain.party.dto.request.PartyGetRequest;
@@ -36,7 +35,6 @@ import org.prgrms.wumo.domain.party.dto.response.PartyGetResponse;
 import org.prgrms.wumo.domain.party.dto.response.PartyRegisterResponse;
 import org.prgrms.wumo.domain.party.model.Party;
 import org.prgrms.wumo.domain.party.model.PartyMember;
-import org.prgrms.wumo.domain.party.repository.InvitationRepository;
 import org.prgrms.wumo.domain.party.repository.PartyMemberRepository;
 import org.prgrms.wumo.domain.party.repository.PartyRepository;
 import org.prgrms.wumo.global.exception.custom.PartyNotEmptyException;
@@ -56,12 +54,6 @@ class PartyServiceTest {
 
 	@Mock
 	PartyMemberRepository partyMemberRepository;
-
-	@Mock
-	InvitationRepository invitationRepository;
-
-	@Mock
-	ImageRepository imageRepository;
 
 	@InjectMocks
 	PartyService partyService;
@@ -369,15 +361,6 @@ class PartyServiceTest {
 			then(partyMemberRepository)
 					.should()
 					.findByPartyIdAndIsLeader(party.getId());
-			then(imageRepository)
-					.should()
-					.delete(party.getCoverImage());
-			then(invitationRepository)
-					.should()
-					.deleteAllByParty(party);
-			then(partyMemberRepository)
-					.should()
-					.delete(partyMember);
 			then(partyRepository)
 					.should()
 					.deleteById(party.getId());


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

- 전체 도메인 삭제 이벤트 처리

### ⛏ 중점 사항

- 회원 탈퇴 유스케이스는 없어서 관련 이벤트 처리는 하지 않았습니다.
- 일부 테스트 중 Image Delete 과정에서 기대하지 않은 값이 오는 경우를 방지하기 위해 null 또는 공백 방지 로직을 추가했습니다.

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-434]

[WUMO-434]: https://shoekream.atlassian.net/browse/WUMO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ