### PR TITLE
[WUMO-450] Route 목록 조회 좋아요순 정렬 기능 커서 수정

### DIFF
--- a/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepository.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/repository/RouteCustomRepository.java
@@ -8,7 +8,7 @@ import org.prgrms.wumo.domain.route.model.Route;
 
 public interface RouteCustomRepository {
 
-	List<Route> findAllByCursorAndSearchWord(Long cursorId, int pageSize, SortType sortType, String searchWord);
+	List<Route> findAllByCursorAndSearchWord(Route route, int pageSize, SortType sortType, String searchWord);
 
 	Optional<Route> findByPartyId(long partyId);
 }

--- a/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
+++ b/src/main/java/org/prgrms/wumo/domain/route/service/RouteService.java
@@ -77,7 +77,7 @@ public class RouteService {
 	@Transactional(readOnly = true)
 	public RouteGetAllResponses getAllRoute(RouteGetAllRequest routeGetAllRequest) {
 		List<Route> routes = routeRepository.findAllByCursorAndSearchWord(
-				routeGetAllRequest.cursorId(),
+				getCursorRoute(routeGetAllRequest.cursorId()),
 				routeGetAllRequest.pageSize(),
 				routeGetAllRequest.sortType(),
 				routeGetAllRequest.searchWord()
@@ -144,6 +144,14 @@ public class RouteService {
 			lastId = routeLikeIds.get(routeLikeIds.size() - 1);
 		}
 		return lastId;
+	}
+
+	private Route getCursorRoute(Long cursorId) {
+		Route cursorRoute = null;
+		if(cursorId != null) {
+			cursorRoute = getRouteEntity(cursorId);
+		}
+		return cursorRoute;
 	}
 
 	private Route getRouteEntity(long routeId) {


### PR DESCRIPTION
<!-- 제목 : [이슈번호] <도메인 영어로> <기능 이름> 기능 구현 
참고) PR 단위는 유저스토리 -->

### 📝 작업 요약

<!-- 작업을 간략하게 요약해주세요 -->

- 루트 목록 조회  좋아요순 정렬 시의 커서 수정

### ⛏ 중점 사항

<!-- 리뷰어가 집중적으로 보았으면 하는 내용을 적어주세요(리뷰 포인트, 질문, etc) -->

- 현재 식별자만 고려한 페이지네이션으로 인해 같은 페이지가 뜨는 버그 발생해 커서의 좋아요수와 식별자 모두 고려하는 것으로 수정

### 💡 관련 이슈

<!-- 발생했던 이슈에 대한 설명, 링크 또는 첨부 파일 -->

- Resolved : [WUMO-451]

[WUMO-451]: https://shoekream.atlassian.net/browse/WUMO-451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ